### PR TITLE
style: clippy -D warnings の赤を機械修正して CI を緑にする

### DIFF
--- a/frontend/src-tauri/src/calibration/gamma.rs
+++ b/frontend/src-tauri/src/calibration/gamma.rs
@@ -71,7 +71,7 @@ pub fn restore_gamma() -> ControlResult {
             drop(saved);
             return set_gamma(gamma);
         }
-        return ControlResult::failure("No saved gamma to restore");
+        ControlResult::failure("No saved gamma to restore")
     }
 
     #[cfg(target_os = "macos")]
@@ -249,7 +249,7 @@ fn detect_gamma_linux() -> GammaStatus {
                     if parts.len() >= 2 {
                         let gamma_str = parts[1].trim();
                         let gamma_parts: Vec<&str> = gamma_str.split(':').collect();
-                        if let Some(gamma_str) = gamma_parts.get(0) {
+                        if let Some(gamma_str) = gamma_parts.first() {
                             if let Ok(gamma_val) = gamma_str.parse::<f32>() {
                                 let is_default = (gamma_val - 1.0).abs() < 0.05;
 
@@ -312,20 +312,20 @@ fn set_gamma_linux(gamma: f32) -> ControlResult {
     }
 
     // Set gamma
-    let gamma_str = format!("{:.2}:{:.2}:{:.2}", gamma, gamma, gamma);
+    let gamma_str = format!("{gamma:.2}:{gamma:.2}:{gamma:.2}");
     let result = Command::new("xrandr")
-        .args(&["--output", display_name, "--gamma", &gamma_str])
+        .args(["--output", display_name, "--gamma", &gamma_str])
         .output();
 
     match result {
         Ok(output) if output.status.success() => {
-            ControlResult::success(format!("Gamma set to {:.2} on {}", gamma, display_name))
+            ControlResult::success(format!("Gamma set to {gamma:.2} on {display_name}"))
         }
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            ControlResult::failure(format!("xrandr failed: {}", stderr))
+            ControlResult::failure(format!("xrandr failed: {stderr}"))
         }
-        Err(e) => ControlResult::failure(format!("Error: {}", e)),
+        Err(e) => ControlResult::failure(format!("Error: {e}")),
     }
 }
 

--- a/frontend/src-tauri/src/calibration/night_mode.rs
+++ b/frontend/src-tauri/src/calibration/night_mode.rs
@@ -91,7 +91,7 @@ fn disable_night_mode_windows() -> ControlResult {
 #[cfg(target_os = "linux")]
 fn detect_night_mode_linux() -> NightModeStatus {
     // Check if redshift is running
-    if let Ok(output) = Command::new("pgrep").args(&["-x", "redshift"]).output() {
+    if let Ok(output) = Command::new("pgrep").args(["-x", "redshift"]).output() {
         if output.status.success() && !output.stdout.is_empty() {
             return NightModeStatus {
                 supported: true,
@@ -102,7 +102,7 @@ fn detect_night_mode_linux() -> NightModeStatus {
     }
 
     // Check if f.lux is running
-    if let Ok(output) = Command::new("pgrep").args(&["-x", "fluxgui"]).output() {
+    if let Ok(output) = Command::new("pgrep").args(["-x", "fluxgui"]).output() {
         if output.status.success() && !output.stdout.is_empty() {
             return NightModeStatus {
                 supported: true,
@@ -122,14 +122,14 @@ fn detect_night_mode_linux() -> NightModeStatus {
 #[cfg(target_os = "linux")]
 fn disable_night_mode_linux() -> ControlResult {
     // Try to kill redshift
-    if let Ok(output) = Command::new("pkill").args(&["-x", "redshift"]).output() {
+    if let Ok(output) = Command::new("pkill").args(["-x", "redshift"]).output() {
         if output.status.success() {
             return ControlResult::success("Redshift disabled");
         }
     }
 
     // Try to kill f.lux
-    if let Ok(output) = Command::new("pkill").args(&["-x", "fluxgui"]).output() {
+    if let Ok(output) = Command::new("pkill").args(["-x", "fluxgui"]).output() {
         if output.status.success() {
             return ControlResult::success("f.lux disabled");
         }

--- a/frontend/src-tauri/src/calibration/types.rs
+++ b/frontend/src-tauri/src/calibration/types.rs
@@ -41,6 +41,9 @@ pub struct NightModeStatus {
 }
 
 impl NightModeStatus {
+    // Used by the non-Linux/Windows/macOS cfg fallback in night_mode.rs;
+    // dead on this platform's build only.
+    #[allow(dead_code)]
     pub fn not_supported(message: impl Into<String>) -> Self {
         Self {
             supported: false,
@@ -49,6 +52,9 @@ impl NightModeStatus {
         }
     }
 
+    // Symmetric status constructor (mirrors GammaStatus::error); reserved for
+    // platform-specific error paths.
+    #[allow(dead_code)]
     pub fn error(message: impl Into<String>) -> Self {
         Self {
             supported: true,
@@ -75,6 +81,9 @@ impl HDRStatus {
         }
     }
 
+    // Symmetric status constructor (mirrors GammaStatus::error); reserved for
+    // platform-specific error paths.
+    #[allow(dead_code)]
     pub fn error(message: impl Into<String>) -> Self {
         Self {
             supported: true,

--- a/frontend/src-tauri/src/displays.rs
+++ b/frontend/src-tauri/src/displays.rs
@@ -39,10 +39,7 @@ pub fn group_displays_by_position(displays: &[DisplayInfo], axis: &str) -> Vec<V
 
     for display in displays {
         let coord = if axis == "x" { display.x } else { display.y };
-        groups
-            .entry(coord)
-            .or_insert_with(Vec::new)
-            .push(display.clone());
+        groups.entry(coord).or_default().push(display.clone());
     }
 
     // Sort groups by coordinate

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use calibration::{CalibrationStatus, ControlResult};
 use displays::{print_display_list, select_displays, DisplayInfo};
 use pattern_loader::load_pattern_with_params;
 use patterns::{load_patterns, PatternsResponse};
-use playlist::{Playlist, PlaylistRunner};
+use playlist::Playlist;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -20,7 +20,7 @@ use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 fn get_patterns() -> Result<PatternsResponse, String> {
     match load_patterns() {
         Ok(patterns) => Ok(PatternsResponse { patterns }),
-        Err(e) => Err(format!("Failed to load patterns: {}", e)),
+        Err(e) => Err(format!("Failed to load patterns: {e}")),
     }
 }
 
@@ -29,7 +29,7 @@ fn get_patterns() -> Result<PatternsResponse, String> {
 fn get_pattern(pattern_id: String, params: HashMap<String, String>) -> Result<Value, String> {
     match load_pattern_with_params(&pattern_id, params) {
         Ok(pattern) => Ok(pattern),
-        Err(e) => Err(format!("Failed to load pattern '{}': {}", pattern_id, e)),
+        Err(e) => Err(format!("Failed to load pattern '{pattern_id}': {e}")),
     }
 }
 
@@ -70,10 +70,9 @@ fn load_playlist(path: String) -> Result<Playlist, String> {
 
     if playlist_path.extension().and_then(|s| s.to_str()) == Some("json") {
         playlist::load_playlist_json(&playlist_path)
-            .map_err(|e| format!("Failed to load playlist: {}", e))
+            .map_err(|e| format!("Failed to load playlist: {e}"))
     } else {
-        playlist::load_playlist(&playlist_path)
-            .map_err(|e| format!("Failed to load playlist: {}", e))
+        playlist::load_playlist(&playlist_path).map_err(|e| format!("Failed to load playlist: {e}"))
     }
 }
 
@@ -84,23 +83,22 @@ pub fn run(pattern: String, display_spec: String, list_displays: bool) {
             move |app, args, _cwd| {
                 // This callback is triggered when a second instance is launched
                 log::info!(
-                    "Single instance: Another instance attempted to start with args: {:?}",
-                    args
+                    "Single instance: Another instance attempted to start with args: {args:?}"
                 );
 
                 // If args contain --pattern, switch to that pattern
                 if let Some(pattern_arg_idx) = args.iter().position(|arg| arg == "--pattern") {
                     if let Some(new_pattern) = args.get(pattern_arg_idx + 1) {
-                        log::info!("Switching to pattern: {}", new_pattern);
+                        log::info!("Switching to pattern: {new_pattern}");
 
                         // Switch pattern on all display windows by navigating to new URL
                         for i in 0..8 {
-                            let window_label = format!("display-{}", i);
+                            let window_label = format!("display-{i}");
                             if let Some(window) = app.get_webview_window(&window_label) {
                                 let url = if cfg!(debug_assertions) {
-                                    format!("http://localhost:3000/?pattern={}", new_pattern)
+                                    format!("http://localhost:3000/?pattern={new_pattern}")
                                 } else {
-                                    format!("tauri://localhost/?pattern={}", new_pattern)
+                                    format!("tauri://localhost/?pattern={new_pattern}")
                                 };
                                 let js = format!(
                                     "window.location.href = '{}';",
@@ -153,15 +151,15 @@ pub fn run(pattern: String, display_spec: String, list_displays: bool) {
             let selected_displays = select_displays(&display_spec, &all_displays);
 
             if selected_displays.is_empty() {
-                eprintln!("[ERROR] No displays selected with spec: {}", display_spec);
+                eprintln!("[ERROR] No displays selected with spec: {display_spec}");
                 std::process::exit(1);
             }
 
             // Build URL with pattern parameter
             let url = if cfg!(debug_assertions) {
-                format!("http://localhost:3000/?pattern={}", pattern)
+                format!("http://localhost:3000/?pattern={pattern}")
             } else {
-                format!("tauri://localhost/?pattern={}", pattern)
+                format!("tauri://localhost/?pattern={pattern}")
             };
 
             // Get the default window (created by tauri.conf.json)
@@ -172,7 +170,7 @@ pub fn run(pattern: String, display_spec: String, list_displays: bool) {
 
             // Create a window for each selected display
             for (i, display) in selected_displays.iter().enumerate() {
-                let window_label = format!("display-{}", i);
+                let window_label = format!("display-{i}");
 
                 WebviewWindowBuilder::new(
                     app,

--- a/frontend/src-tauri/src/pattern_expander.rs
+++ b/frontend/src-tauri/src/pattern_expander.rs
@@ -106,7 +106,7 @@ impl PatternExpander {
                         serde_json::Number::from_f64(float_val).context("Invalid float value")?,
                     ))
                 } else {
-                    Err(anyhow::anyhow!("Cannot parse '{}' as number", value))
+                    Err(anyhow::anyhow!("Cannot parse '{value}' as number"))
                 }
             }
             "boolean" => {
@@ -151,7 +151,7 @@ impl PatternExpander {
         // Replace all {{paramName}} occurrences
         let mut result = s.to_string();
         for (key, value) in params {
-            let placeholder = format!("{{{{{}}}}}", key);
+            let placeholder = format!("{{{{{key}}}}}");
             if result.contains(&placeholder) {
                 let replacement = match value {
                     Value::String(s) => s.clone(),
@@ -247,8 +247,8 @@ impl PatternExpander {
     /// Load a pattern file by path
     fn load_pattern_file(&self, path: &str) -> Result<Value> {
         // Normalize path
-        let file_path = if path.starts_with('/') {
-            PathBuf::from(&path[1..])
+        let file_path = if let Some(stripped) = path.strip_prefix('/') {
+            PathBuf::from(stripped)
         } else {
             self.patterns_dir.join(path)
         };

--- a/frontend/src-tauri/src/pattern_loader.rs
+++ b/frontend/src-tauri/src/pattern_loader.rs
@@ -10,17 +10,17 @@ use std::fs;
 /// Load pattern from YAML file
 pub fn load_pattern_file(pattern_id: &str) -> Result<Value> {
     let patterns_dir = get_patterns_dir()?;
-    let pattern_path = patterns_dir.join(format!("{}.yaml", pattern_id));
+    let pattern_path = patterns_dir.join(format!("{pattern_id}.yaml"));
 
     if !pattern_path.exists() {
-        return Err(anyhow::anyhow!("Pattern not found: {}", pattern_id));
+        return Err(anyhow::anyhow!("Pattern not found: {pattern_id}"));
     }
 
     let content = fs::read_to_string(&pattern_path)
-        .with_context(|| format!("Failed to read pattern file: {:?}", pattern_path))?;
+        .with_context(|| format!("Failed to read pattern file: {pattern_path:?}"))?;
 
     let yaml: Value = serde_yaml::from_str(&content)
-        .with_context(|| format!("Failed to parse YAML: {:?}", pattern_path))?;
+        .with_context(|| format!("Failed to parse YAML: {pattern_path:?}"))?;
 
     Ok(yaml)
 }

--- a/frontend/src-tauri/src/patterns.rs
+++ b/frontend/src-tauri/src/patterns.rs
@@ -68,7 +68,7 @@ pub fn load_patterns_from(dir: &Path) -> Result<Vec<PatternInfo>> {
                 }
             }
             Err(e) => {
-                log::warn!("Failed to process glob entry: {}", e);
+                log::warn!("Failed to process glob entry: {e}");
             }
         }
     }
@@ -82,10 +82,10 @@ pub fn load_patterns_from(dir: &Path) -> Result<Vec<PatternInfo>> {
 /// Load pattern metadata from a single YAML file
 fn load_pattern_info(path: &Path) -> Result<PatternInfo> {
     let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read pattern file: {:?}", path))?;
+        .with_context(|| format!("Failed to read pattern file: {path:?}"))?;
 
     let yaml: HashMap<String, serde_yaml::Value> = serde_yaml::from_str(&content)
-        .with_context(|| format!("Failed to parse YAML: {:?}", path))?;
+        .with_context(|| format!("Failed to parse YAML: {path:?}"))?;
 
     let pattern_id = path
         .file_stem()

--- a/frontend/src-tauri/src/playlist/runner.rs
+++ b/frontend/src-tauri/src/playlist/runner.rs
@@ -63,10 +63,9 @@ impl PlaylistRunner {
                 let source = self.sources.get(self.current_index);
                 self.current_index += 1;
 
-                if self.current_index >= self.sources.len() {
-                    if self.playlist.playback.loop_playback {
-                        self.current_index = 0;
-                    }
+                if self.current_index >= self.sources.len() && self.playlist.playback.loop_playback
+                {
+                    self.current_index = 0;
                 }
 
                 source
@@ -82,10 +81,9 @@ impl PlaylistRunner {
                 let source = self.sources.get(self.current_index);
                 self.current_index += 1;
 
-                if self.current_index >= self.sources.len() {
-                    if self.playlist.playback.loop_playback {
-                        self.current_index = 0;
-                    }
+                if self.current_index >= self.sources.len() && self.playlist.playback.loop_playback
+                {
+                    self.current_index = 0;
                 }
 
                 source


### PR DESCRIPTION
## 関連 Issue
closes #3

## 概要

CI rust ジョブの `cargo clippy -- -D warnings` を塞いでいた42件の赤を機械修正で解消する。これにより #11 で追加した `cargo test` ステップが初めて CI 上で作動するようになる。

## 内訳（すべて挙動不変）
- `uninlined_format_args` ×26（`format!("{}", x)` → `format!("{x}")`）
- `needless_borrows_for_generic_args` ×5（`.args(&[...])` → `.args([...])`）
- `collapsible_if` ×2（runner.rs のネスト if を `&&` に統合）
- `unwrap_or_default` ×1 / `needless_return` ×1 / `get_first` ×1
- `manual_strip` ×1（`&path[1..]` → `strip_prefix('/')`・等価）
- 未使用 import 削除 ×1（lib.rs の `PlaylistRunner`）
- dead_code ×3 は**削除せず `#[allow(dead_code)]`**（calibration/types.rs）。`NightModeStatus::not_supported` は他OSの `cfg(not(any(...)))` フォールバックで実使用のため、削除すると非Linux/Win/macビルドが壊れる。安全側で allow + 意図コメント。

## 検証
- `cargo clippy -- -D warnings`: 0 エラー
- `cargo clippy --all-targets -- -D warnings`: 0 エラー
- `cargo test`: 13 緑（lib 2 + golden_e2e 11）・挙動不変