### PR TITLE
feat: スライドショー再生を UI に配線（pattern/image/url の3ソース）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,8 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.9.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "@types/react": "^18.3.11",
@@ -28,13 +30,22 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "husky": "^9.1.7",
+        "jsdom": "^25.0.1",
         "lint-staged": "^16.2.6",
         "postcss": "^8.4.0",
         "prettier": "^3.6.2",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^2.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -48,6 +59,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -303,6 +335,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -349,6 +391,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1638,6 +1795,90 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1996,6 +2237,92 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2017,6 +2344,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2124,6 +2461,33 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -2258,6 +2622,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2299,6 +2687,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2314,6 +2719,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2414,6 +2829,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2453,6 +2881,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2466,12 +2901,47 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2491,12 +2961,49 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2525,6 +3032,29 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
@@ -2539,6 +3069,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -2550,6 +3093,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2822,6 +3421,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2838,6 +3447,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2983,6 +3602,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -3050,6 +3686,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -3134,6 +3809,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3151,10 +3839,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3162,6 +3879,47 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/husky": {
@@ -3178,6 +3936,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3215,6 +3986,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -3324,6 +4105,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3357,6 +4145,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3606,6 +4435,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3614,6 +4450,37 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge2": {
@@ -3653,6 +4520,29 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -3664,6 +4554,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3743,6 +4643,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3853,6 +4760,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3889,6 +4809,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4119,6 +5056,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4175,6 +5142,14 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4219,6 +5194,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve": {
@@ -4349,6 +5338,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4371,6 +5367,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4417,6 +5433,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -4470,6 +5493,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -4535,6 +5572,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -4612,6 +5662,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -4680,6 +5737,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -4707,6 +5771,56 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4718,6 +5832,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4910,6 +6050,1170 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4924,6 +7228,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -5020,6 +7341,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "tauri:build": "tauri build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
+    "test": "vitest run",
     "format": "prettier --write .",
     "prepare": "cd .. && husky frontend/.husky"
   },
@@ -26,6 +27,8 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.9.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.11",
@@ -38,12 +41,14 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "husky": "^9.1.7",
+    "jsdom": "^25.0.1",
     "lint-staged": "^16.2.6",
     "postcss": "^8.4.0",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^2.1.9"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/frontend/public/playlists/digital-signage.yaml
+++ b/frontend/public/playlists/digital-signage.yaml
@@ -29,17 +29,20 @@ sources:
     path: "@/patterns/checker-with-dot.yaml"
     duration: 5000
 
-  # Random pattern (inline)
+  # Inline pattern (drawn directly from primitives the web renderer supports;
+  # `preset`/`background` are Rust-only and would render black on the web).
   - type: inline
     pattern:
       canvas:
         width: 1920
         height: 1080
       nodes:
+        # Full-frame solid fill via a rect primitive.
         - id: bg
-          type: background
-          preset: grayscale
-          params:
-            steps: 16
-            direction: horizontal
+          type: rect
+          x: 0
+          y: 0
+          width: 1920
+          height: 1080
+          fill: "#2E4053"
     duration: 10000

--- a/frontend/public/playlists/digital-signage.yaml
+++ b/frontend/public/playlists/digital-signage.yaml
@@ -1,0 +1,45 @@
+# Digital Signage Example
+# Mixes web pages, patterns, and images in sequence
+
+playback:
+  order: sequence
+  loop: true
+  defaultDuration: 10000
+
+sources:
+  # Company dashboard (web page)
+  - type: url
+    url: "https://example.com/dashboard"
+    readonly: true
+    duration: 30000
+
+  # Test pattern (for display calibration)
+  - type: pattern
+    path: "@/patterns/colorbar-simple.yaml"
+    duration: 5000
+
+  # Announcement image
+  - type: image
+    src: "@/images/announcement.png"
+    fit: contain
+    duration: 15000
+
+  # Another pattern
+  - type: pattern
+    path: "@/patterns/checker-with-dot.yaml"
+    duration: 5000
+
+  # Random pattern (inline)
+  - type: inline
+    pattern:
+      canvas:
+        width: 1920
+        height: 1080
+      nodes:
+        - id: bg
+          type: background
+          preset: grayscale
+          params:
+            steps: 16
+            direction: horizontal
+    duration: 10000

--- a/frontend/public/playlists/image-slideshow.yaml
+++ b/frontend/public/playlists/image-slideshow.yaml
@@ -1,0 +1,34 @@
+# Image Slideshow
+# Displays images from URLs in random order
+
+playback:
+  order: random
+  loop: true
+  defaultDuration: 5000
+
+sources:
+  # Random images from picsum.photos
+  - type: image
+    src: "https://picsum.photos/1920/1080?random=1"
+    fit: cover
+    duration: 5000
+
+  - type: image
+    src: "https://picsum.photos/1920/1080?random=2"
+    fit: cover
+    duration: 5000
+
+  - type: image
+    src: "https://picsum.photos/1920/1080?random=3"
+    fit: cover
+    duration: 5000
+
+  - type: image
+    src: "https://picsum.photos/1920/1080?random=4"
+    fit: cover
+    duration: 5000
+
+  - type: image
+    src: "https://picsum.photos/1920/1080?random=5"
+    fit: cover
+    duration: 5000

--- a/frontend/public/playlists/test-pattern-loop.yaml
+++ b/frontend/public/playlists/test-pattern-loop.yaml
@@ -1,0 +1,28 @@
+# Test Pattern Loop
+# Cycles through standard test patterns for display calibration
+
+playback:
+  order: sequence
+  loop: true
+  defaultDuration: 3000
+
+sources:
+  # SMPTE Color Bars
+  - type: pattern
+    path: "@/patterns/colorbar-simple.yaml"
+    duration: 3000
+
+  # Checkerboard
+  - type: pattern
+    path: "@/patterns/checker-with-dot.yaml"
+    duration: 3000
+
+  # Grayscale
+  - type: pattern
+    path: "@/patterns/grayscale-with-lines.yaml"
+    duration: 3000
+
+  # Multi-layer test
+  - type: pattern
+    path: "@/patterns/multi-layer-example.yaml"
+    duration: 5000

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,22 @@
 import { useMemo } from "react";
 import PatternDisplay from "./components/PatternDisplay";
+import SlideshowView from "./components/SlideshowView";
 
 function App() {
-  // Get pattern from URL search params
-  const pattern = useMemo(() => {
+  // Read both `?playlist=` and `?pattern=` once. Playlist takes precedence;
+  // when absent we fall back to the existing single-pattern display (backward
+  // compatible).
+  const { playlist, pattern } = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
-    return params.get("pattern") || "colorbar";
+    return {
+      playlist: params.get("playlist"),
+      pattern: params.get("pattern") || "colorbar",
+    };
   }, []);
+
+  if (playlist) {
+    return <SlideshowView name={playlist} />;
+  }
 
   return <PatternDisplay pattern={pattern} />;
 }

--- a/frontend/src/components/SlideshowView.tsx
+++ b/frontend/src/components/SlideshowView.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import NodeRenderer from "./NodeRenderer";
+import { useSlideshow } from "../hooks/useSlideshow";
+import { resolvePath } from "../lib/pathResolver";
+import type { Playlist, PlaylistSource } from "../lib/playlistTypes";
+import type { XSGPattern } from "../lib/types";
+
+interface SlideshowViewProps {
+  /** Playlist name (e.g. "digital-signage") taken from `?playlist=`. */
+  name: string;
+}
+
+/**
+ * SlideshowView — full-screen slideshow renderer.
+ *
+ * Loads the named playlist (Tauri command in desktop, public/ fetch in web),
+ * drives playback via `useSlideshow`, and renders the current source by type.
+ * It is intentionally a thin shell: all ordering/timing lives in
+ * `useSlideshow` / `slideshowSequencer`, all per-source drawing in the small
+ * `Slide*` components below.
+ */
+export default function SlideshowView({ name }: SlideshowViewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [playlist, setPlaylist] = useState<Playlist | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Request fullscreen on mount (screensaver/signage use case).
+  useEffect(() => {
+    if (containerRef.current && document.documentElement.requestFullscreen) {
+      document.documentElement.requestFullscreen().catch((err) => {
+        console.warn("Fullscreen request failed:", err);
+      });
+    }
+  }, []);
+
+  // Load the playlist definition.
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { safeInvoke } = await import("../lib/tauriCompat");
+        const data = await safeInvoke<Playlist>("load_playlist", {
+          path: name,
+        });
+        if (!cancelled) setPlaylist(data);
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Failed to load playlist:", err);
+          setError(
+            err instanceof Error ? err.message : "Failed to load playlist"
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  const slideshow = useSlideshow(playlist);
+
+  // Keyboard controls: Space = play/pause, ArrowRight/Left = next/prev.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === " ") {
+        e.preventDefault();
+        slideshow.toggle();
+      } else if (e.key === "ArrowRight") {
+        slideshow.next();
+      } else if (e.key === "ArrowLeft") {
+        slideshow.prev();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [slideshow]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="w-screen h-screen overflow-hidden relative bg-black flex items-center justify-center"
+      style={{ imageRendering: "pixelated" }}
+    >
+      <SlideshowBody
+        loading={loading}
+        error={error}
+        playlist={playlist}
+        current={slideshow.current}
+        isStopped={slideshow.isStopped}
+      />
+    </div>
+  );
+}
+
+interface SlideshowBodyProps {
+  loading: boolean;
+  error: string | null;
+  playlist: Playlist | null;
+  current: PlaylistSource | undefined;
+  isStopped: boolean;
+}
+
+function SlideshowBody({
+  loading,
+  error,
+  playlist,
+  current,
+  isStopped,
+}: SlideshowBodyProps) {
+  if (loading) {
+    return <CenterMessage>Loading playlist...</CenterMessage>;
+  }
+  if (error) {
+    return <CenterMessage>Error: {error}</CenterMessage>;
+  }
+  if (!playlist) {
+    return <CenterMessage>No playlist</CenterMessage>;
+  }
+  if (!current) {
+    return (
+      <CenterMessage>
+        {isStopped ? "Slideshow finished" : "No slides"}
+      </CenterMessage>
+    );
+  }
+  return <Slide source={current} />;
+}
+
+function CenterMessage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-black text-white">
+      {children}
+    </div>
+  );
+}
+
+/** Dispatch a single source to its renderer. */
+function Slide({ source }: { source: PlaylistSource }) {
+  switch (source.type) {
+    case "pattern":
+      return <PatternSlide path={source.path} />;
+    case "inline":
+      return <InlineSlide pattern={source.pattern} />;
+    case "image":
+      return <ImageSlide source={source} />;
+    case "url":
+      return <UrlSlide source={source} />;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Extract a pattern id usable by `get_pattern` from a source `path`.
+ * "@/patterns/colorbar-simple.yaml" -> "colorbar-simple".
+ */
+function patternIdFromPath(path: string): string {
+  const fileName = path.replace(/\\/g, "/").split("/").pop() || path;
+  return fileName.replace(/\.(ya?ml|json)$/i, "");
+}
+
+/** Pattern source: load via get_pattern then render nodes (like PatternDisplay). */
+function PatternSlide({ path }: { path: string }) {
+  const [pattern, setPattern] = useState<XSGPattern | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setError(null);
+      setPattern(null);
+      try {
+        const { safeInvoke } = await import("../lib/tauriCompat");
+        const data = await safeInvoke<XSGPattern>("get_pattern", {
+          patternId: patternIdFromPath(path),
+          params: {},
+        });
+        if (!cancelled) setPattern(data);
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Failed to load pattern"
+          );
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+
+  if (error) return <CenterMessage>Error: {error}</CenterMessage>;
+  if (!pattern || !pattern.nodes) return null;
+  return <PatternNodes pattern={pattern} />;
+}
+
+/** Inline source: render the embedded pattern's nodes directly. */
+function InlineSlide({ pattern }: { pattern: Record<string, unknown> }) {
+  const data = pattern as unknown as XSGPattern;
+  if (!data.nodes) return null;
+  return <PatternNodes pattern={data} />;
+}
+
+/** Shared pattern-node renderer (mirror of PatternDisplay's render path). */
+function PatternNodes({ pattern }: { pattern: XSGPattern }) {
+  return (
+    <>
+      {(pattern.nodes || []).map((node) => (
+        <NodeRenderer key={node.id} node={node} />
+      ))}
+    </>
+  );
+}
+
+/** Image source: <img> with object-fit, or tiled background when `tile`. */
+function ImageSlide({
+  source,
+}: {
+  source: Extract<PlaylistSource, { type: "image" }>;
+}) {
+  const src = useMemo(() => resolvePath(source.src), [source.src]);
+
+  if (source.tile) {
+    const sizePx = source.tileSize ? `${source.tileSize}px` : "auto";
+    return (
+      <div
+        className="w-full h-full"
+        style={{
+          backgroundImage: `url("${src}")`,
+          backgroundRepeat: "repeat",
+          backgroundSize: sizePx,
+          backgroundColor: "black",
+        }}
+      />
+    );
+  }
+
+  // object-fit: fall back to "contain" (screensaver-friendly, no cropping).
+  const objectFit = (source.fit ?? "contain") as "contain" | "cover" | "fill";
+  return (
+    <img
+      src={src}
+      alt=""
+      className="w-full h-full"
+      style={{ objectFit, backgroundColor: "black" }}
+    />
+  );
+}
+
+/** URL source: full-screen <iframe>. readonly disables interaction. */
+function UrlSlide({
+  source,
+}: {
+  source: Extract<PlaylistSource, { type: "url" }>;
+}) {
+  return (
+    <iframe
+      src={source.url}
+      title="slideshow-url"
+      className="w-full h-full border-0"
+      // readonly signage: block all pointer/keyboard interaction and lock down
+      // the embedded page. sandbox without allow-scripts would break many
+      // dashboards, so we keep scripts but cut user interaction via CSS.
+      sandbox={
+        source.readonly
+          ? "allow-scripts allow-same-origin"
+          : "allow-scripts allow-same-origin allow-forms allow-popups"
+      }
+      style={{
+        pointerEvents: source.readonly ? "none" : "auto",
+        backgroundColor: "black",
+      }}
+    />
+  );
+}

--- a/frontend/src/components/SlideshowView.tsx
+++ b/frontend/src/components/SlideshowView.tsx
@@ -276,13 +276,16 @@ function UrlSlide({
       src={source.url}
       title="slideshow-url"
       className="w-full h-full border-0"
-      // readonly signage: block all pointer/keyboard interaction and lock down
-      // the embedded page. sandbox without allow-scripts would break many
-      // dashboards, so we keep scripts but cut user interaction via CSS.
+      // Playlist URLs are assumed to be trusted (a signage operator's own
+      // dashboards). We still avoid the sandbox-escape combo: `allow-scripts`
+      // together with `allow-same-origin` lets a framed page remove its own
+      // sandbox, so we never grant both. Scripts stay enabled (dashboards need
+      // them) but same-origin is withheld. readonly signage additionally blocks
+      // all pointer/keyboard interaction via CSS.
       sandbox={
         source.readonly
-          ? "allow-scripts allow-same-origin"
-          : "allow-scripts allow-same-origin allow-forms allow-popups"
+          ? "allow-scripts allow-popups"
+          : "allow-scripts allow-forms allow-popups"
       }
       style={{
         pointerEvents: source.readonly ? "none" : "auto",

--- a/frontend/src/components/SlideshowView.tsx
+++ b/frontend/src/components/SlideshowView.tsx
@@ -210,14 +210,23 @@ function InlineSlide({ pattern }: { pattern: Record<string, unknown> }) {
   return <PatternNodes pattern={data} />;
 }
 
-/** Shared pattern-node renderer (mirror of PatternDisplay's render path). */
+/**
+ * Shared pattern-node renderer (mirror of PatternDisplay's render path).
+ *
+ * Each `NodeRenderer` returns its own full-screen `<canvas class="w-full
+ * h-full">`. To layer them (multi-node patterns like multi-layer-example),
+ * wrap them in a `relative` box and pin every canvas with `absolute inset-0` so
+ * they overlap instead of stacking/centering inside the parent flex container.
+ */
 function PatternNodes({ pattern }: { pattern: XSGPattern }) {
   return (
-    <>
+    <div className="relative w-full h-full">
       {(pattern.nodes || []).map((node) => (
-        <NodeRenderer key={node.id} node={node} />
+        <div key={node.id} className="absolute inset-0">
+          <NodeRenderer node={node} />
+        </div>
       ))}
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/hooks/useSlideshow.test.tsx
+++ b/frontend/src/hooks/useSlideshow.test.tsx
@@ -1,0 +1,396 @@
+/**
+ * useSlideshow — タイマー駆動フックのテスト（fake timers・決定論）。
+ *
+ * これは Rust golden（`src-tauri/tests/golden_e2e.rs` の runner 系）の
+ * フロント鏡像のうち「時間で次へ送る」レイヤを担う。順序/duration/loop の
+ * 意味論そのものは純粋シーケンサ（slideshowSequencer.test.ts）で検証済みなので、
+ * ここではフックが
+ *   - 各スライドの duration 経過で advance する（runner の get_duration → 次の get_next）
+ *   - pause/play でタイマーを止める/再開する
+ *   - loop=false の sequence で全件後に停止する（runner の should_continue=false 相当）
+ *   - 個別 duration / defaultDuration を尊重する
+ *   - next/prev が即時にカーソルを動かす
+ * を主張する。見た目（SlideshowView の描画）は対象外＝別途ライブ確認。
+ *
+ * 非決定（shuffle/random）は持ち込まない。タイマーは vi.useFakeTimers() で
+ * 完全に決定論化し、advanceTimersByTime で時間を手動で進める。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSlideshow } from "./useSlideshow";
+import type { Order, Playlist, PlaylistSource } from "../lib/playlistTypes";
+
+// ---------------------------------------------------------------------------
+// ヘルパ（sequencer テストと同じ流儀で Playlist を組む）
+// ---------------------------------------------------------------------------
+
+/** pattern source を1件作る（path と任意の個別 duration）。 */
+function patternSource(path: string, duration?: number): PlaylistSource {
+  return duration === undefined
+    ? { type: "pattern", path }
+    : { type: "pattern", path, duration };
+}
+
+/** useSlideshow に渡す Playlist を直接構築する。 */
+function makePlaylist(
+  order: Order,
+  loop: boolean,
+  defaultDuration: number | undefined,
+  sources: PlaylistSource[]
+): Playlist {
+  return {
+    playback:
+      defaultDuration === undefined
+        ? { order, loop }
+        : { order, loop, defaultDuration },
+    sources,
+  };
+}
+
+/** current の path を取り出す（検証用）。 */
+function currentPath(s: PlaylistSource | undefined): string | undefined {
+  if (s === undefined) return undefined;
+  if (s.type === "pattern") return s.path;
+  throw new Error(`テストは pattern source のみ使う: ${JSON.stringify(s)}`);
+}
+
+// fake timers をテストごとに張り替える（リークさせない）。
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// 自動送り — duration 経過で次のスライドへ
+// ---------------------------------------------------------------------------
+
+describe("自動送り（タイマー）", () => {
+  it("各スライドの個別 duration 経過で次へ送られる", () => {
+    // --- 仕様: 再生中、現在スライドの duration(ms) 経過で advance する ---
+    // a=1000ms, b=2000ms, c=3000ms。runner の get_next→get_duration→次の get_next に対応。
+    const playlist = makePlaylist("sequence", true, undefined, [
+      patternSource("a", 1000),
+      patternSource("b", 2000),
+      patternSource("c", 3000),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+
+    // 初期は autoPlay=true で先頭 a を表示・再生中。
+    expect(currentPath(result.current.current)).toBe("a");
+    expect(result.current.isPlaying).toBe(true);
+
+    // a の 1000ms 経過 → b へ。
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+
+    // b は 2000ms。1999ms ではまだ送られない（境界の手前）。
+    act(() => {
+      vi.advanceTimersByTime(1999);
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+
+    // 残り 1ms で 2000ms 到達 → c へ。
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(currentPath(result.current.current)).toBe("c");
+  });
+
+  it("duration 未指定スライドは defaultDuration を尊重する", () => {
+    // --- 仕様: 個別 duration が無いスライドは playback.defaultDuration(ms) で送られる ---
+    const playlist = makePlaylist("sequence", true, 2500, [
+      patternSource("a"), // 個別なし → defaultDuration=2500
+      patternSource("b"),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+    expect(currentPath(result.current.current)).toBe("a");
+
+    // defaultDuration 未満では送られない。
+    act(() => {
+      vi.advanceTimersByTime(2499);
+    });
+    expect(currentPath(result.current.current)).toBe("a");
+
+    // 2500ms 到達で b へ。
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+  });
+
+  it("loop:true は末尾の次で先頭へ wrap して送り続ける", () => {
+    // --- 仕様: loop=true は末尾消化後に先頭へ wrap し、タイマーで回り続ける ---
+    const playlist = makePlaylist("sequence", true, 1000, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+    expect(currentPath(result.current.current)).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+
+    // b の次（末尾の次）で先頭 a へ wrap。
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("a");
+    // wrap 後も再生継続。
+    expect(result.current.isPlaying).toBe(true);
+    expect(result.current.isStopped).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pause / play — タイマーの停止と再開
+// ---------------------------------------------------------------------------
+
+describe("pause / play", () => {
+  it("pause でタイマーが止まり、時間が経っても送られない", () => {
+    // --- 仕様: pause() 後は isPlaying=false になりタイマーが解除され、自動送りが止まる ---
+    const playlist = makePlaylist("sequence", true, 1000, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+    expect(currentPath(result.current.current)).toBe("a");
+
+    act(() => {
+      result.current.pause();
+    });
+    expect(result.current.isPlaying).toBe(false);
+
+    // pause 中は何ms 経っても a のまま。
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(currentPath(result.current.current)).toBe("a");
+  });
+
+  it("play で再開し、新しい duration からタイマーが再武装される", () => {
+    // --- 仕様: pause→play でタイマーが再武装され、現在スライドの duration 経過で再び送られる ---
+    const playlist = makePlaylist("sequence", true, 1000, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+
+    act(() => {
+      result.current.pause();
+    });
+    act(() => {
+      vi.advanceTimersByTime(5000); // pause 中は無効
+    });
+    expect(currentPath(result.current.current)).toBe("a");
+
+    // 再開すると a の 1000ms から再び計測される。
+    act(() => {
+      result.current.play();
+    });
+    expect(result.current.isPlaying).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+  });
+
+  it("toggle は再生状態を反転する", () => {
+    // --- 仕様: toggle() は isPlaying を反転する（再生↔一時停止のトグル）---
+    const playlist = makePlaylist("sequence", true, 1000, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+    expect(result.current.isPlaying).toBe(true);
+
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.isPlaying).toBe(false);
+
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.isPlaying).toBe(true);
+  });
+
+  it("autoPlay:false は再生せず、最初のスライドで止まったまま", () => {
+    // --- 仕様: autoPlay=false で初期化すると isPlaying=false でタイマーは動かない ---
+    const playlist = makePlaylist("sequence", true, 1000, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    const { result } = renderHook(() =>
+      useSlideshow(playlist, { autoPlay: false })
+    );
+    expect(result.current.isPlaying).toBe(false);
+    expect(currentPath(result.current.current)).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    // 自動送りしないので a のまま。
+    expect(currentPath(result.current.current)).toBe("a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 停止 — loop:false の sequence で全件後に止まる（runner.should_continue=false 相当）
+// ---------------------------------------------------------------------------
+
+describe("loop:false の停止", () => {
+  it("全件消化後に current が undefined になり isStopped=true で止まる", () => {
+    // --- 仕様: loop=false の sequence は全件タイマーで送ったあと、
+    //          現在ソースが undefined（=停止シグナル）になり isStopped=true になる ---
+    // Rust golden の「全件後 get_next()=None / should_continue()=false」のフロント対応。
+    const playlist = makePlaylist("sequence", false, 1000, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+    expect(currentPath(result.current.current)).toBe("a");
+    expect(result.current.isStopped).toBe(false);
+
+    // a → b
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+    expect(result.current.isStopped).toBe(false);
+
+    // b の duration 経過で末尾を超え、current=undefined・停止。
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.current).toBeUndefined();
+    expect(result.current.isStopped).toBe(true);
+  });
+
+  it("停止後はさらに時間が経っても何も起きない（タイマー解除済み）", () => {
+    // --- 仕様: 停止後は current=undefined のままタイマーが再武装されない ---
+    const playlist = makePlaylist("sequence", false, 1000, [
+      patternSource("a"),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+    // 1件だけ → a の duration 経過で末尾超過＝停止。
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.current).toBeUndefined();
+    expect(result.current.isStopped).toBe(true);
+
+    // さらに時間を進めてもクラッシュせず停止のまま。
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.current).toBeUndefined();
+    expect(result.current.isStopped).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 手動ナビゲーション — next / prev は即時にカーソルを動かす
+// ---------------------------------------------------------------------------
+
+describe("手動ナビゲーション", () => {
+  it("next は即時に次のスライドへ進む", () => {
+    // --- 仕様: next() は advance を即時に呼び、タイマーを待たず次へ送る ---
+    const playlist = makePlaylist("sequence", true, 5000, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+    expect(currentPath(result.current.current)).toBe("a");
+
+    // タイマー(5000ms)を待たずに next で即 b へ。
+    act(() => {
+      result.current.next();
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+    expect(result.current.index).toBe(1);
+  });
+
+  it("prev は即時に前のスライドへ戻る", () => {
+    // --- 仕様: prev() は retreat を即時に呼び、1つ前のスライドへ戻す ---
+    const playlist = makePlaylist("sequence", true, 5000, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+
+    act(() => {
+      result.current.next(); // a→b
+      result.current.next(); // b→c
+    });
+    expect(currentPath(result.current.current)).toBe("c");
+
+    act(() => {
+      result.current.prev(); // c→b
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+    expect(result.current.index).toBe(1);
+  });
+
+  it("next 後はその新スライドの duration からタイマーが再計測される", () => {
+    // --- 仕様: next() でカーソルが動くとタイマーが再武装され、新スライドの duration で送られる ---
+    const playlist = makePlaylist("sequence", true, undefined, [
+      patternSource("a", 5000),
+      patternSource("b", 1000),
+      patternSource("c", 5000),
+    ]);
+    const { result } = renderHook(() => useSlideshow(playlist));
+
+    // a の途中(2000ms)で next → b へ。残りタイマーは破棄される。
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(currentPath(result.current.current)).toBe("a");
+    act(() => {
+      result.current.next();
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+
+    // b は 1000ms。a の残り(3000ms)ではなく b の 1000ms で c へ。
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("c");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 空 / null playlist — 安全に停止扱い
+// ---------------------------------------------------------------------------
+
+describe("空・null playlist", () => {
+  it("null playlist は current=undefined・isStopped=true", () => {
+    // --- 仕様: playlist が null なら何も表示せず停止扱い ---
+    const { result } = renderHook(() => useSlideshow(null));
+    expect(result.current.current).toBeUndefined();
+    expect(result.current.isStopped).toBe(true);
+    // タイマーを進めてもクラッシュしない。
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.current).toBeUndefined();
+  });
+
+  it("空 sources は current=undefined・isStopped=true", () => {
+    // --- 仕様: sources が空なら何も表示せず停止扱い（runner と同じ）---
+    const playlist = makePlaylist("sequence", true, 1000, []);
+    const { result } = renderHook(() => useSlideshow(playlist));
+    expect(result.current.current).toBeUndefined();
+    expect(result.current.isStopped).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useSlideshow.test.tsx
+++ b/frontend/src/hooks/useSlideshow.test.tsx
@@ -150,6 +150,81 @@ describe("自動送り（タイマー）", () => {
 });
 
 // ---------------------------------------------------------------------------
+// random — duration 経過ごとに別スライドへ進む（フリーズ回帰ガード）
+//   旧バグ: advance が同一 state を返すと setState が bail → 再描画されず
+//           タイマーも再武装されず random が1枚で凍る。seeded rng で決定論化。
+// ---------------------------------------------------------------------------
+
+describe("random（フリーズ回帰ガード）", () => {
+  /** 与えた float 列を順に返す決定論 rng（尽きたら 0）。 */
+  function seqRng(values: number[]): () => number {
+    let i = 0;
+    return () => (i < values.length ? values[i++] : 0);
+  }
+
+  it("duration 経過ごとに乱択スライドへ進み続ける（凍らない）", () => {
+    // --- 仕様: random + loop:true は duration 経過ごとに別スライドへ送られる。
+    //          advance が毎回新 state を返すので再描画・タイマー再武装が起きる ---
+    const playlist = makePlaylist("random", true, 1000, [
+      patternSource("a"), // index 0
+      patternSource("b"), // index 1
+      patternSource("c"), // index 2
+    ]);
+    // floor(rng*3): 0.5→1(b), 0.99→2(c), 0.0→0(a)
+    const rng = seqRng([0.5, 0.99, 0.0]);
+    const { result } = renderHook(() => useSlideshow(playlist, { rng }));
+
+    // 初期は currentIndex=0 → a を表示。
+    expect(currentPath(result.current.current)).toBe("a");
+
+    // 1000ms 経過 → advance(rng=0.5) → index 1 → b。
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+
+    // さらに 1000ms → advance(rng=0.99) → index 2 → c（凍っていない）。
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("c");
+
+    // さらに 1000ms → advance(rng=0.0) → index 0 → a。
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("a");
+    // ずっと再生中・停止していない（#20: random は止まらない）。
+    expect(result.current.isPlaying).toBe(true);
+    expect(result.current.isStopped).toBe(false);
+  });
+
+  it("loop:false でも止まらず送られ続ける（#20）", () => {
+    // --- 仕様: random は loop=false でも停止しない。duration ごとに進み続ける ---
+    const playlist = makePlaylist("random", false, 1000, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    // floor(rng*2): 0.9→1(b), 0.1→0(a)
+    const rng = seqRng([0.9, 0.1]);
+    const { result } = renderHook(() => useSlideshow(playlist, { rng }));
+    expect(currentPath(result.current.current)).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("b");
+    expect(result.current.isStopped).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(currentPath(result.current.current)).toBe("a");
+    expect(result.current.isStopped).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // pause / play — タイマーの停止と再開
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/hooks/useSlideshow.ts
+++ b/frontend/src/hooks/useSlideshow.ts
@@ -73,13 +73,13 @@ export function useSlideshow(
     setIsPlaying(autoPlay);
   }, [initialState, autoPlay]);
 
-  // For `random`, getCurrent samples a fresh index each call. We freeze that
-  // sample per advance step into `current` so a slide does not "flicker"
-  // between renders while it is on screen. The sample is recomputed only when
-  // the underlying sequencer state changes (i.e. on each advance/next/prev).
+  // `current` is a pure read of `sources[currentIndex]` (the sequencer chooses
+  // the random index in `advance`, not here), so it only changes when the
+  // sequencer state changes identity — i.e. on each advance/next/prev. A random
+  // slide therefore stays put between renders and never flickers.
   const current = useMemo<PlaylistSource | undefined>(
-    () => (seqState ? getCurrent(seqState, rng) : undefined),
-    [seqState, rng]
+    () => (seqState ? getCurrent(seqState) : undefined),
+    [seqState]
   );
 
   // A non-looping playlist is "stopped" once getCurrent yields nothing while
@@ -91,8 +91,11 @@ export function useSlideshow(
   }, [seqState, current]);
 
   const doAdvance = useCallback(() => {
-    setSeqState((prev) => (prev ? advance(prev) : prev));
-  }, []);
+    // Thread the injectable RNG so `random` order is deterministic in tests and
+    // re-samples a fresh index on every advance (= a new state, so the timer
+    // re-arms and the slide actually changes).
+    setSeqState((prev) => (prev ? advance(prev, rng) : prev));
+  }, [rng]);
 
   const doRetreat = useCallback(() => {
     setSeqState((prev) => (prev ? retreat(prev) : prev));
@@ -149,7 +152,16 @@ export function useSlideshow(
   };
 }
 
-/** Narrow helper: a non-null playback config (used for duration resolution). */
+/**
+ * Narrow helper: a non-null playback config (used for duration resolution).
+ *
+ * The `null` branch is a defensive default that is in practice unreachable: the
+ * only caller is the auto-advance effect, which has already bailed out when
+ * `seqState`/`current` is absent, and `current` can only exist when `playlist`
+ * (and thus `playlist.playback`) does. The fallback's `order`/`loop` are never
+ * consulted here — only `defaultDuration` would be, and it is absent — so this
+ * is purely a type-narrowing guard, not live behaviour.
+ */
 function playlistPlayback(playlist: Playlist | null): Playlist["playback"] {
   return playlist?.playback ?? { order: "sequence", loop: true };
 }

--- a/frontend/src/hooks/useSlideshow.ts
+++ b/frontend/src/hooks/useSlideshow.ts
@@ -1,0 +1,155 @@
+/**
+ * useSlideshow — runtime playback state for a playlist.
+ *
+ * The ordering/timing semantics live in the pure `slideshowSequencer` module
+ * (the TS mirror of Rust `PlaylistRunner`). This hook only owns the React
+ * runtime state (`SlideshowState`) and the timer that advances slides. The
+ * `Playlist` definition passed in is never mutated.
+ *
+ * Public API:
+ * - `current`     — the source to display now (or undefined when stopped/empty).
+ * - `isPlaying`   — whether the auto-advance timer is running.
+ * - `isStopped`   — true once a non-looping playlist has run past its end.
+ * - `index`       — current cursor (sequence/shuffle); meaningless for random.
+ * - `play()/pause()/toggle()` — control the timer.
+ * - `next()/prev()` — manual navigation (resets the timer).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Playlist, PlaylistSource } from "../lib/playlistTypes";
+import {
+  advance,
+  durationFor,
+  getCurrent,
+  prepare,
+  retreat,
+  shouldContinue,
+  type Rng,
+  type SequencerState,
+} from "../lib/slideshowSequencer";
+
+export interface SlideshowState {
+  /** Source to render now, or undefined when nothing should be shown. */
+  current: PlaylistSource | undefined;
+  /** Auto-advance timer running. */
+  isPlaying: boolean;
+  /** Non-looping playlist exhausted (no further slides). */
+  isStopped: boolean;
+  /** Current cursor (sequence/shuffle). For `random` this stays 0. */
+  index: number;
+  play: () => void;
+  pause: () => void;
+  toggle: () => void;
+  next: () => void;
+  prev: () => void;
+}
+
+export interface UseSlideshowOptions {
+  /** Start playing immediately. Default true. */
+  autoPlay?: boolean;
+  /** Injectable RNG (tests/determinism). Default Math.random. */
+  rng?: Rng;
+}
+
+export function useSlideshow(
+  playlist: Playlist | null,
+  options: UseSlideshowOptions = {}
+): SlideshowState {
+  const { autoPlay = true, rng } = options;
+
+  // Prepare once per playlist identity (one-time shuffle for `shuffle` order).
+  const initialState = useMemo<SequencerState | null>(
+    () => (playlist ? prepare(playlist, rng) : null),
+    [playlist, rng]
+  );
+
+  const [seqState, setSeqState] = useState<SequencerState | null>(initialState);
+  const [isPlaying, setIsPlaying] = useState(autoPlay);
+
+  // Reset sequencer state whenever the playlist (and thus prepared state)
+  // changes identity.
+  useEffect(() => {
+    setSeqState(initialState);
+    setIsPlaying(autoPlay);
+  }, [initialState, autoPlay]);
+
+  // For `random`, getCurrent samples a fresh index each call. We freeze that
+  // sample per advance step into `current` so a slide does not "flicker"
+  // between renders while it is on screen. The sample is recomputed only when
+  // the underlying sequencer state changes (i.e. on each advance/next/prev).
+  const current = useMemo<PlaylistSource | undefined>(
+    () => (seqState ? getCurrent(seqState, rng) : undefined),
+    [seqState, rng]
+  );
+
+  // A non-looping playlist is "stopped" once getCurrent yields nothing while
+  // there are sources (cursor ran past the end). Empty playlist is also stopped.
+  const isStopped = useMemo<boolean>(() => {
+    if (!seqState) return true;
+    if (seqState.sources.length === 0) return true;
+    return !shouldContinue(seqState) && current === undefined;
+  }, [seqState, current]);
+
+  const doAdvance = useCallback(() => {
+    setSeqState((prev) => (prev ? advance(prev) : prev));
+  }, []);
+
+  const doRetreat = useCallback(() => {
+    setSeqState((prev) => (prev ? retreat(prev) : prev));
+  }, []);
+
+  const play = useCallback(() => setIsPlaying(true), []);
+  const pause = useCallback(() => setIsPlaying(false), []);
+  const toggle = useCallback(() => setIsPlaying((p) => !p), []);
+
+  const next = useCallback(() => {
+    doAdvance();
+  }, [doAdvance]);
+
+  const prev = useCallback(() => {
+    doRetreat();
+  }, [doRetreat]);
+
+  // Auto-advance timer. Re-armed whenever the current slide or play state
+  // changes. Uses the per-source duration (mirrors runner's get_duration).
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    if (!isPlaying || !seqState || !current) {
+      return;
+    }
+
+    const ms = durationFor(current, playlistPlayback(playlist));
+    timerRef.current = setTimeout(() => {
+      doAdvance();
+    }, ms);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [isPlaying, seqState, current, playlist, doAdvance]);
+
+  return {
+    current,
+    isPlaying,
+    isStopped,
+    index: seqState?.currentIndex ?? 0,
+    play,
+    pause,
+    toggle,
+    next,
+    prev,
+  };
+}
+
+/** Narrow helper: a non-null playback config (used for duration resolution). */
+function playlistPlayback(playlist: Playlist | null): Playlist["playback"] {
+  return playlist?.playback ?? { order: "sequence", loop: true };
+}

--- a/frontend/src/lib/playlistTypes.ts
+++ b/frontend/src/lib/playlistTypes.ts
@@ -1,0 +1,106 @@
+/**
+ * Playlist Type Definitions (definition data, immutable)
+ *
+ * These types mirror the Rust serde shapes in
+ * `src-tauri/src/playlist/models.rs`. They describe the *definition* of a
+ * playlist (loaded from YAML/JSON) and must never be used as a container for
+ * runtime playback state (current index, isPlaying, ...). Runtime state lives
+ * in `slideshowSequencer.ts` / `useSlideshow.ts` under separate `~State` types.
+ *
+ * Wire-format notes (must match Rust):
+ * - `Order` serializes lowercase: "sequence" | "random" | "shuffle".
+ * - `Playback.loop_playback` is serialized as `loop` (serde rename).
+ * - `Playback.default_duration` is serialized as `defaultDuration`.
+ * - `PlaylistSource` is a tagged union with discriminator `type`.
+ * - `ImageSource.tile_size` is serialized as `tileSize`.
+ */
+
+/** Playback order. Mirrors Rust `Order` (rename_all = "lowercase"). */
+export type Order = "sequence" | "random" | "shuffle";
+
+/**
+ * Playback configuration (definition).
+ * `loop` defaults to `true` on the Rust side (`default_loop`), so when a
+ * playlist comes through with `loop` absent we treat it as `true`.
+ */
+export interface Playback {
+  order: Order;
+  /** Wire key is `loop`. Defaults to true (matches Rust `default_loop`). */
+  loop: boolean;
+  /** Wire key is `defaultDuration`. Milliseconds. */
+  defaultDuration?: number;
+}
+
+/** Pattern source (file path to a pattern YAML). */
+export interface PatternSource {
+  type: "pattern";
+  path: string;
+  duration?: number;
+}
+
+/** URL source (web page shown in an iframe). */
+export interface UrlSource {
+  type: "url";
+  url: string;
+  readonly?: boolean;
+  duration?: number;
+}
+
+/** Image source (single image, optionally tiled). */
+export interface ImageSource {
+  type: "image";
+  src: string;
+  fit?: "contain" | "cover" | "fill";
+  tile?: boolean;
+  /** Wire key is `tileSize`. */
+  tileSize?: number;
+  duration?: number;
+}
+
+/** Inline source (a pattern definition embedded directly in the playlist). */
+export interface InlineSource {
+  type: "inline";
+  /** Inline XSG pattern object (canvas/nodes/...). */
+  pattern: Record<string, unknown>;
+  duration?: number;
+}
+
+/** Tagged union of all playlist sources. Discriminator is `type`. */
+export type PlaylistSource =
+  | PatternSource
+  | UrlSource
+  | ImageSource
+  | InlineSource;
+
+/** Layer constraints for the (not-yet-supported) generator. */
+export interface LayerConstraints {
+  min?: number;
+  max?: number;
+}
+
+/** Generator constraints. */
+export interface Constraints {
+  presets?: string[];
+  layers?: LayerConstraints;
+  colors?: string[];
+}
+
+/**
+ * Pattern generator configuration (definition).
+ * Generator-driven sources are out of scope for this phase; the type is kept
+ * so the wire shape round-trips, but `prepare()` ignores it (mirrors the
+ * runner's `TODO` for generator integration).
+ */
+export interface Generator {
+  enabled: boolean;
+  count?: number;
+  duration?: number;
+  constraints?: Constraints;
+}
+
+/** Playlist definition. Mirrors Rust `Playlist`. */
+export interface Playlist {
+  playback: Playback;
+  sources?: PlaylistSource[];
+  generator?: Generator;
+}

--- a/frontend/src/lib/slideshowSequencer.smoke.test.ts
+++ b/frontend/src/lib/slideshowSequencer.smoke.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Smoke test — confirms the vitest harness runs and the pure sequencer's
+ * sequence-order path behaves. The exhaustive ordering suite (random/shuffle,
+ * loop boundaries, durations, RNG injection) is written by a follow-up agent;
+ * this only proves the infrastructure is green.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  advance,
+  durationFor,
+  getCurrent,
+  prepare,
+} from "./slideshowSequencer";
+import type { Playlist } from "./playlistTypes";
+
+const playlist: Playlist = {
+  playback: { order: "sequence", loop: true, defaultDuration: 4000 },
+  sources: [
+    { type: "pattern", path: "@/patterns/a.yaml", duration: 1000 },
+    { type: "pattern", path: "@/patterns/b.yaml" },
+  ],
+};
+
+describe("slideshowSequencer (smoke)", () => {
+  it("walks sequence order and wraps when looping", () => {
+    const s0 = prepare(playlist);
+    const first = getCurrent(s0);
+    expect(first).toEqual(playlist.sources![0]);
+
+    const s1 = advance(s0);
+    expect(getCurrent(s1)).toEqual(playlist.sources![1]);
+
+    // loop:true wraps back to the start.
+    const s2 = advance(s1);
+    expect(getCurrent(s2)).toEqual(playlist.sources![0]);
+  });
+
+  it("resolves duration via source -> defaultDuration -> 5000", () => {
+    expect(durationFor(playlist.sources![0], playlist.playback)).toBe(1000);
+    // second source has no duration -> falls back to defaultDuration.
+    expect(durationFor(playlist.sources![1], playlist.playback)).toBe(4000);
+  });
+});

--- a/frontend/src/lib/slideshowSequencer.test.ts
+++ b/frontend/src/lib/slideshowSequencer.test.ts
@@ -236,13 +236,32 @@ describe("shuffle", () => {
 });
 
 // ---------------------------------------------------------------------------
-// random — 入力メンバーを返す・advance は状態不変（#20）
+// random — 入力メンバーを返す・advance で次の乱択へ進む（#20: 止まらない）
 //   Rust: runner_inproc_random_returns_only_input_members
+//   ※ 旧仕様（advance は state 不変）から改修。random も advance で次の index を
+//     再サンプルし、毎回「新しい state」を返す（さもないと React が bail して
+//     再描画されず random がフリーズする）。getCurrent は render 中に rng を
+//     呼ばない純粋関数で、sources[currentIndex] を返す（seq/shuffle と同じ）。
 // ---------------------------------------------------------------------------
 
 describe("random", () => {
-  it("getCurrent は毎回入力集合のメンバーを返す", () => {
-    // --- 仕様: Random は毎回 0..len から乱択する。返る要素は必ず入力集合のメンバー ---
+  it("getCurrent は currentIndex の source を返す（純粋・rng を呼ばない）", () => {
+    // --- 仕様: random でも getCurrent は sources[currentIndex] を返す。
+    //          乱択は advance 側で行うので getCurrent は決定論的 ---
+    const playlist = makePlaylist("random", true, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+    ]);
+    const s = prepare(playlist); // currentIndex = 0
+    // 何度呼んでも同じ（render 中にフリッカしない）。
+    expect(sourcePath(getCurrent(s))).toBe("a");
+    expect(sourcePath(getCurrent(s))).toBe("a");
+  });
+
+  it("advance で次の乱択へ進む（毎回入力集合のメンバー）", () => {
+    // --- 仕様: advance(state, rng) は index = floor(rng()*len) を再サンプルする。
+    //          得られる current は必ず入力集合のメンバー ---
     const inputPaths = ["a", "b", "c"];
     const playlist = makePlaylist(
       "random",
@@ -250,41 +269,60 @@ describe("random", () => {
       undefined,
       inputPaths.map((p) => patternSource(p))
     );
-    const s = prepare(playlist);
     const input = new Set(inputPaths);
-    // 様々な rng 値で 30 回引いて、すべて入力メンバーであることを確認。
+    // 様々な rng 値で 30 回 advance し、毎回 current が入力メンバーであることを確認。
     const rng = seqRng([0.0, 0.34, 0.67, 0.99, 0.5, 0.1, 0.9, 0.2, 0.8, 0.45]);
+    let s = prepare(playlist);
     for (let i = 0; i < 30; i++) {
-      const got = sourcePath(getCurrent(s, rng));
+      s = advance(s, rng);
+      const got = sourcePath(getCurrent(s));
       expect(input.has(got)).toBe(true);
     }
   });
 
-  it("seeded rng で getCurrent の具体値が決まる", () => {
-    // --- 仕様: index = floor(rng() * len)。rng を固定すれば返る source も決まる ---
+  it("seeded rng で advance 後の具体値が決まる（決定論）", () => {
+    // --- 仕様: advance の index = floor(rng() * len)。rng を固定すれば進む先も決まる ---
     const playlist = makePlaylist("random", true, undefined, [
       patternSource("a"), // index 0
       patternSource("b"), // index 1
       patternSource("c"), // index 2
     ]);
-    const s = prepare(playlist);
+    const s0 = prepare(playlist);
     // floor(0.0*3)=0→a, floor(0.5*3)=1→b, floor(0.99*3)=2→c
-    expect(sourcePath(getCurrent(s, seqRng([0.0])))).toBe("a");
-    expect(sourcePath(getCurrent(s, seqRng([0.5])))).toBe("b");
-    expect(sourcePath(getCurrent(s, seqRng([0.99])))).toBe("c");
+    expect(sourcePath(getCurrent(advance(s0, seqRng([0.0]))))).toBe("a");
+    expect(sourcePath(getCurrent(advance(s0, seqRng([0.5]))))).toBe("b");
+    expect(sourcePath(getCurrent(advance(s0, seqRng([0.99]))))).toBe("c");
   });
 
-  it("advance は状態を変えない（index 不変＝止まらない / #20）", () => {
-    // --- 仕様: Random は advance でカーソルを動かさない（既知仕様 #20: 永遠に止まらない）---
+  it("advance は必ず新しい state を返す（参照が変わる＝React が再描画する）", () => {
+    // --- 仕様: random の advance は同一参照を返してはならない。
+    //          同一参照だと setState((p)=>advance(p)) が bail して再描画されず凍る ---
+    const playlist = makePlaylist("random", true, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+    ]);
+    const s0 = prepare(playlist);
+    const s1 = advance(s0, seqRng([0.5])); // index 1 へ
+    expect(s1).not.toBe(s0); // 参照が必ず変わる
+    expect(s1.currentIndex).toBe(1);
+  });
+
+  it("loop:false でも止まらない（#20: random は永遠に続く）", () => {
+    // --- 仕様: random は loop に関わらず止まらない。currentIndex は常に範囲内なので
+    //          getCurrent は undefined を返さず、shouldContinue も true のまま ---
     const playlist = makePlaylist("random", false, undefined, [
       patternSource("a"),
       patternSource("b"),
     ]);
-    const s0 = prepare(playlist);
-    const s1 = advance(s0);
-    // currentIndex が 0 のまま（状態オブジェクトの index 不変）。
-    expect(s1.currentIndex).toBe(s0.currentIndex);
-    expect(s1.currentIndex).toBe(0);
+    let s = prepare(playlist);
+    const rng = seqRng([0.9, 0.1, 0.6, 0.3, 0.8]);
+    for (let i = 0; i < 5; i++) {
+      s = advance(s, rng);
+      // 何回 advance しても current は出続け、継続判定も true。
+      expect(getCurrent(s)).toBeDefined();
+      expect(shouldContinue(s)).toBe(true);
+    }
   });
 });
 

--- a/frontend/src/lib/slideshowSequencer.test.ts
+++ b/frontend/src/lib/slideshowSequencer.test.ts
@@ -1,0 +1,451 @@
+/**
+ * slideshowSequencer — exhaustive ordering suite (pure functions, deterministic).
+ *
+ * これは Rust の golden（`src-tauri/tests/golden_e2e.rs` の runner 系）の
+ * フロント鏡像。Rust の `PlaylistRunner` が `get_next()` で「返す」と「index 前進」を
+ * 同時に行うのに対し、TS 側は `getCurrent()`（返す）と `advance()`（前進）に分離している。
+ * したがって Rust の `get_next()` 1回 = TS の `getCurrent()` → `advance()` の対に対応する。
+ *
+ * 非決定（shuffle/random）は `Rng = () => number` を注入して決定論化する。
+ * Rust 流儀に倣い、shuffle/random は原則として順序でなく集合（メンバーシップ）で主張し、
+ * seeded rng を使うときだけ具体値も確認する（Math.random は順序 assert に持ち込まない）。
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  advance,
+  durationFor,
+  getCurrent,
+  prepare,
+  retreat,
+  shouldContinue,
+  DEFAULT_SLIDE_DURATION_MS,
+  type Rng,
+  type SequencerState,
+} from "./slideshowSequencer";
+import type { Order, Playlist, PlaylistSource } from "./playlistTypes";
+
+// ---------------------------------------------------------------------------
+// テスト用ヘルパ
+// ---------------------------------------------------------------------------
+
+/** pattern source を1件作る（path と任意の個別 duration）。Rust の pattern_source 相当。 */
+function patternSource(path: string, duration?: number): PlaylistSource {
+  return duration === undefined
+    ? { type: "pattern", path }
+    : { type: "pattern", path, duration };
+}
+
+/** runner に渡す Playlist を直接構築する。Rust の make_playlist 相当。 */
+function makePlaylist(
+  order: Order,
+  loop: boolean,
+  defaultDuration: number | undefined,
+  sources: PlaylistSource[]
+): Playlist {
+  return {
+    playback:
+      defaultDuration === undefined
+        ? { order, loop }
+        : { order, loop, defaultDuration },
+    sources,
+  };
+}
+
+/** pattern source の path を取り出す（検証用）。Rust の source_path 相当。 */
+function sourcePath(s: PlaylistSource | undefined): string {
+  if (s && s.type === "pattern") return s.path;
+  throw new Error(`テストは pattern source のみ使う: ${JSON.stringify(s)}`);
+}
+
+/**
+ * 決定論 RNG: 与えた float 列を順に返し、尽きたら 0 を返す。
+ * Fisher–Yates の各ステップで `j = floor(rng() * (i+1))` を踏むので、
+ * 返す値を設計すれば shuffle の結果を完全に固定できる。
+ */
+function seqRng(values: number[]): Rng {
+  let i = 0;
+  return () => (i < values.length ? values[i++] : 0);
+}
+
+// ---------------------------------------------------------------------------
+// prepare — 並べ替え・不変性
+// ---------------------------------------------------------------------------
+
+describe("prepare", () => {
+  it("shuffle は seeded rng で特定順に並べ替える", () => {
+    // --- 仕様: order=shuffle は prepare() で1回だけ Fisher–Yates する ---
+    // shuffled() は i=len-1..1 で j=floor(rng()*(i+1)) を引く。len=4 のとき:
+    //   i=3: rng=0 → j=floor(0*4)=0 → swap(3,0)  [d,b,c,a]
+    //   i=2: rng=0 → j=floor(0*3)=0 → swap(2,0)  [c,b,d,a]
+    //   i=1: rng=0 → j=floor(0*2)=0 → swap(1,0)  [b,c,d,a]
+    // よって rng が常に 0 を返すなら [a,b,c,d] → [b,c,d,a] に固定される。
+    const sources = [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+      patternSource("d"),
+    ];
+    const playlist = makePlaylist("shuffle", false, undefined, sources);
+    const state = prepare(playlist, seqRng([0, 0, 0]));
+    expect(state.sources.map((s) => sourcePath(s))).toEqual([
+      "b",
+      "c",
+      "d",
+      "a",
+    ]);
+  });
+
+  it("sequence は順序を維持する（事前シャッフルしない）", () => {
+    // --- 仕様: order=sequence は投入順をそのまま保持する ---
+    const sources = [patternSource("a"), patternSource("b"), patternSource("c")];
+    const playlist = makePlaylist("sequence", true, undefined, sources);
+    // rng が呼ばれても結果が変わらないことを示すため、攪乱用の値を渡しておく。
+    const state = prepare(playlist, seqRng([0.9, 0.1, 0.5]));
+    expect(state.sources.map((s) => sourcePath(s))).toEqual(["a", "b", "c"]);
+  });
+
+  it("random は順序を維持する（random は事前シャッフルしない）", () => {
+    // --- 仕様: order=random は prepare 時にシャッフルせず、毎回サンプリングする ---
+    const sources = [patternSource("a"), patternSource("b"), patternSource("c")];
+    const playlist = makePlaylist("random", true, undefined, sources);
+    const state = prepare(playlist, seqRng([0.9, 0.1, 0.5]));
+    expect(state.sources.map((s) => sourcePath(s))).toEqual(["a", "b", "c"]);
+  });
+
+  it("Playlist 定義を変更しない（不変性 / 規律2）", () => {
+    // --- 仕様: prepare() は定義(Playlist)を mutate しない（shuffle でも元配列は不変）---
+    const sources = [patternSource("a"), patternSource("b"), patternSource("c")];
+    const playlist = makePlaylist("shuffle", false, undefined, sources);
+    const before = JSON.parse(JSON.stringify(playlist));
+    prepare(playlist, seqRng([0.7, 0.7, 0.7]));
+    expect(playlist).toEqual(before);
+    // 元 sources 配列の参照内容も並べ替わっていないこと。
+    expect(playlist.sources!.map((s) => sourcePath(s))).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("初期 currentIndex は 0", () => {
+    // --- 仕様: prepare 直後のカーソルは先頭(0) ---
+    const playlist = makePlaylist("sequence", true, undefined, [
+      patternSource("a"),
+    ]);
+    expect(prepare(playlist).currentIndex).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sequence — 投入順・loop wrap・非ループ停止
+//   Rust: runner_sequence_order_is_deterministic_and_loops
+//        runner_inproc_should_continue_stops_after_all_items_when_no_loop
+// ---------------------------------------------------------------------------
+
+describe("sequence", () => {
+  it("getCurrent→advance を繰り返すと投入順で出る（決定論）", () => {
+    // --- 仕様: Sequence は投入順をそのまま返す（Rust と同じく順序まで固定検証）---
+    const playlist = makePlaylist("sequence", true, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+    ]);
+    let s = prepare(playlist);
+    expect(sourcePath(getCurrent(s))).toBe("a");
+    s = advance(s);
+    expect(sourcePath(getCurrent(s))).toBe("b");
+    s = advance(s);
+    expect(sourcePath(getCurrent(s))).toBe("c");
+  });
+
+  it("loop:true は末尾の次で先頭へ wrap する", () => {
+    // --- 仕様: loop=true は末尾の次で先頭(0)へ wrap する ---
+    const playlist = makePlaylist("sequence", true, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+    ]);
+    let s = prepare(playlist);
+    s = advance(advance(advance(s))); // a→b→c を消化し、c の次へ
+    // wrap して先頭 a に戻る。
+    expect(sourcePath(getCurrent(s))).toBe("a");
+    s = advance(s);
+    expect(sourcePath(getCurrent(s))).toBe("b");
+  });
+
+  it("loop:false は全件消化後 getCurrent が undefined（=停止）", () => {
+    // --- 仕様: loop=false は全件消化後カーソルが末尾を超え、getCurrent が undefined を返す ---
+    // Rust の「全件消化後の get_next() は None」に対応（末尾超過の境界）。
+    const playlist = makePlaylist("sequence", false, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    let s = prepare(playlist);
+    expect(sourcePath(getCurrent(s))).toBe("a");
+    s = advance(s);
+    expect(sourcePath(getCurrent(s))).toBe("b");
+    s = advance(s); // index=2 == len、wrap しない
+    expect(getCurrent(s)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shuffle — メンバーシップ保存（順序は seeded のみ固定）
+//   Rust: runner_inproc_shuffle_preserves_membership_not_order
+// ---------------------------------------------------------------------------
+
+describe("shuffle", () => {
+  it("advance で全件辿ると集合が入力と一致する（メンバーシップ保存）", () => {
+    // --- 仕様: Shuffle は順序を変えるが集合（メンバーシップ）は保存する ---
+    // Rust 流儀: 順序でなく集合・件数で判定する。
+    const inputPaths = ["a", "b", "c", "d"];
+    const playlist = makePlaylist(
+      "shuffle",
+      false,
+      undefined,
+      inputPaths.map((p) => patternSource(p))
+    );
+    // seeded rng（攪乱あり）でシャッフルしても集合は変わらないことを示す。
+    let s = prepare(playlist, seqRng([0.3, 0.6, 0.1]));
+    const seen = new Set<string>();
+    for (let i = 0; i < inputPaths.length; i++) {
+      seen.add(sourcePath(getCurrent(s)));
+      s = advance(s);
+    }
+    expect(seen).toEqual(new Set(inputPaths));
+  });
+
+  it("seeded rng では順序も具体的に固定される（決定論の確認）", () => {
+    // --- 仕様: shuffle は1回限りの並べ替えで、同じ rng なら順序も再現する ---
+    // rng が常に 0 → [a,b,c,d] が [b,c,d,a] になる（prepare のケースと同じ計算）。
+    const playlist = makePlaylist("shuffle", false, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+      patternSource("d"),
+    ]);
+    let s = prepare(playlist, seqRng([0, 0, 0]));
+    const order: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      order.push(sourcePath(getCurrent(s)));
+      s = advance(s);
+    }
+    expect(order).toEqual(["b", "c", "d", "a"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// random — 入力メンバーを返す・advance は状態不変（#20）
+//   Rust: runner_inproc_random_returns_only_input_members
+// ---------------------------------------------------------------------------
+
+describe("random", () => {
+  it("getCurrent は毎回入力集合のメンバーを返す", () => {
+    // --- 仕様: Random は毎回 0..len から乱択する。返る要素は必ず入力集合のメンバー ---
+    const inputPaths = ["a", "b", "c"];
+    const playlist = makePlaylist(
+      "random",
+      true,
+      undefined,
+      inputPaths.map((p) => patternSource(p))
+    );
+    const s = prepare(playlist);
+    const input = new Set(inputPaths);
+    // 様々な rng 値で 30 回引いて、すべて入力メンバーであることを確認。
+    const rng = seqRng([0.0, 0.34, 0.67, 0.99, 0.5, 0.1, 0.9, 0.2, 0.8, 0.45]);
+    for (let i = 0; i < 30; i++) {
+      const got = sourcePath(getCurrent(s, rng));
+      expect(input.has(got)).toBe(true);
+    }
+  });
+
+  it("seeded rng で getCurrent の具体値が決まる", () => {
+    // --- 仕様: index = floor(rng() * len)。rng を固定すれば返る source も決まる ---
+    const playlist = makePlaylist("random", true, undefined, [
+      patternSource("a"), // index 0
+      patternSource("b"), // index 1
+      patternSource("c"), // index 2
+    ]);
+    const s = prepare(playlist);
+    // floor(0.0*3)=0→a, floor(0.5*3)=1→b, floor(0.99*3)=2→c
+    expect(sourcePath(getCurrent(s, seqRng([0.0])))).toBe("a");
+    expect(sourcePath(getCurrent(s, seqRng([0.5])))).toBe("b");
+    expect(sourcePath(getCurrent(s, seqRng([0.99])))).toBe("c");
+  });
+
+  it("advance は状態を変えない（index 不変＝止まらない / #20）", () => {
+    // --- 仕様: Random は advance でカーソルを動かさない（既知仕様 #20: 永遠に止まらない）---
+    const playlist = makePlaylist("random", false, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    const s0 = prepare(playlist);
+    const s1 = advance(s0);
+    // currentIndex が 0 のまま（状態オブジェクトの index 不変）。
+    expect(s1.currentIndex).toBe(s0.currentIndex);
+    expect(s1.currentIndex).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retreat — UI 専用の後退（Rust runner には無い frontend 限定機能）
+// ---------------------------------------------------------------------------
+
+describe("retreat", () => {
+  it("sequence は1つ前へ戻る", () => {
+    // --- 仕様: retreat は sequence/shuffle のカーソルを1つ戻す ---
+    const playlist = makePlaylist("sequence", true, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+    ]);
+    let s = prepare(playlist);
+    s = advance(advance(s)); // index=2 (c)
+    expect(sourcePath(getCurrent(s))).toBe("c");
+    s = retreat(s);
+    expect(sourcePath(getCurrent(s))).toBe("b");
+  });
+
+  it("loop:true は先頭で末尾へ wrap する", () => {
+    // --- 仕様: loop=true のとき先頭(0)から retreat すると末尾へ wrap する ---
+    const playlist = makePlaylist("sequence", true, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+      patternSource("c"),
+    ]);
+    const s0 = prepare(playlist); // index=0
+    const s1 = retreat(s0);
+    expect(sourcePath(getCurrent(s1))).toBe("c"); // 末尾へ wrap
+  });
+
+  it("loop:false は先頭で 0 に留まる", () => {
+    // --- 仕様: loop=false のとき先頭から retreat しても index は 0 に留まる（負にしない）---
+    const playlist = makePlaylist("sequence", false, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    const s0 = prepare(playlist);
+    const s1 = retreat(s0);
+    expect(s1.currentIndex).toBe(0);
+  });
+
+  it("random は状態を変えない", () => {
+    // --- 仕様: random は retreat しても状態不変（current は毎回サンプリングされる）---
+    const playlist = makePlaylist("random", true, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    const s0 = prepare(playlist);
+    expect(retreat(s0)).toEqual(s0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// durationFor — source.duration > defaultDuration > 5000
+//   Rust: runner_inproc_get_duration_priority_source_then_default_then_fallback
+//        runner_inproc_get_duration_falls_back_to_5000_when_nothing_set
+// ---------------------------------------------------------------------------
+
+describe("durationFor", () => {
+  it("source 個別 duration が最優先", () => {
+    // --- 仕様: source.duration があればそれを最優先で使う ---
+    const playback: Playlist["playback"] = {
+      order: "sequence",
+      loop: false,
+      defaultDuration: 7000,
+    };
+    expect(durationFor(patternSource("s1", 2000), playback)).toBe(2000);
+  });
+
+  it("個別が無ければ playback.defaultDuration を使う", () => {
+    // --- 仕様: source.duration が無ければ defaultDuration にフォールバック ---
+    const playback: Playlist["playback"] = {
+      order: "sequence",
+      loop: false,
+      defaultDuration: 7000,
+    };
+    expect(durationFor(patternSource("s2"), playback)).toBe(7000);
+  });
+
+  it("個別も default も無ければ既定値 5000ms", () => {
+    // --- 仕様: source も default も無いとき既定値 5000ms に落ちる ---
+    const playback: Playlist["playback"] = { order: "sequence", loop: false };
+    expect(durationFor(patternSource("only"), playback)).toBe(
+      DEFAULT_SLIDE_DURATION_MS
+    );
+    expect(DEFAULT_SLIDE_DURATION_MS).toBe(5000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldContinue — 空→false、loop→true、sequence/shuffle は全件後 false
+//   Rust: should_continue 系（loop=false で全件後停止）
+// ---------------------------------------------------------------------------
+
+describe("shouldContinue", () => {
+  it("空リストは false", () => {
+    // --- 仕様: sources が空なら継続しない ---
+    const playlist = makePlaylist("sequence", true, undefined, []);
+    expect(shouldContinue(prepare(playlist))).toBe(false);
+  });
+
+  it("loop:true は全件消化後も常に true", () => {
+    // --- 仕様: loop=true は常に継続（カーソルが進んでも true のまま）---
+    const playlist = makePlaylist("sequence", true, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    let s = prepare(playlist);
+    expect(shouldContinue(s)).toBe(true);
+    s = advance(advance(s)); // 全件消化（loop なので index は wrap して 0）
+    expect(shouldContinue(s)).toBe(true);
+  });
+
+  it("sequence(loop:false) は全件消化後に false", () => {
+    // --- 仕様: loop=false は全件消化後に停止する（Rust の回帰ガード #17 と同義）---
+    const playlist = makePlaylist("sequence", false, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    let s = prepare(playlist);
+    expect(shouldContinue(s)).toBe(true); // 再生前は継続可
+    s = advance(s); // index -> 1
+    expect(shouldContinue(s)).toBe(true); // 1件目消化後もまだ継続可
+    s = advance(s); // index -> 2 (== len)
+    expect(shouldContinue(s)).toBe(false); // 全件後は停止
+  });
+
+  it("shuffle(loop:false) も全件消化後に false", () => {
+    // --- 仕様: shuffle も sequence と同じカーソル制御なので全件後 false ---
+    const playlist = makePlaylist("shuffle", false, undefined, [
+      patternSource("a"),
+      patternSource("b"),
+    ]);
+    let s = prepare(playlist, seqRng([0, 0]));
+    s = advance(advance(s)); // index -> 2 (== len)
+    expect(shouldContinue(s)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// エッジケース: 空リストでの各関数の安全性
+// ---------------------------------------------------------------------------
+
+describe("空リストの安全性", () => {
+  const emptyState = (order: Order): SequencerState =>
+    prepare(makePlaylist(order, true, undefined, []));
+
+  it("getCurrent は undefined", () => {
+    // --- 仕様: 空リストでは何も表示しない ---
+    expect(getCurrent(emptyState("sequence"))).toBeUndefined();
+    expect(getCurrent(emptyState("random"))).toBeUndefined();
+  });
+
+  it("advance / retreat は状態を変えない", () => {
+    // --- 仕様: 空リストで advance/retreat してもクラッシュせず状態不変 ---
+    const s = emptyState("sequence");
+    expect(advance(s)).toEqual(s);
+    expect(retreat(s)).toEqual(s);
+  });
+});

--- a/frontend/src/lib/slideshowSequencer.ts
+++ b/frontend/src/lib/slideshowSequencer.ts
@@ -1,0 +1,192 @@
+/**
+ * Slideshow Sequencer (pure ordering logic)
+ *
+ * This is the TypeScript mirror of the Rust `PlaylistRunner`
+ * (`src-tauri/src/playlist/runner.rs`). It contains *only* pure functions over
+ * an explicit, immutable-ish state value so the ordering semantics can be unit
+ * tested without React. `useSlideshow` wraps these in React state.
+ *
+ * Behaviour is intentionally identical to the Rust runner:
+ *
+ * - prepare(): for `order === "shuffle"`, shuffle the sources **once**;
+ *   `sequence` and `random` keep the source array as-is (random does NOT
+ *   pre-shuffle — it samples each time).
+ * - getCurrent(): the source the runner's `get_next()` would *return* for the
+ *   current state. For sequence/shuffle that is `sources[currentIndex]`
+ *   (`undefined` once the index has run past the end with loop disabled). For
+ *   random it samples a uniformly random index each call.
+ * - advance(): the index bookkeeping `get_next()` performs *after* returning a
+ *   source. sequence/shuffle do `currentIndex += 1`, wrapping to 0 only when
+ *   `loop` is true. random leaves the index untouched (so it never stops).
+ * - durationFor(): `source.duration ?? playback.defaultDuration ?? 5000`.
+ *
+ * Separation of concerns (doctrine 規律2): `Playlist` (definition) is never
+ * mutated. The mutable bits live in `SequencerState`.
+ */
+
+import type { Order, Playlist, PlaylistSource } from "./playlistTypes";
+
+/** Default per-slide duration in ms when neither source nor playback set one. */
+export const DEFAULT_SLIDE_DURATION_MS = 5000;
+
+/**
+ * Runtime ordering state. This is the `~State` companion to the `Playlist`
+ * definition: it holds the prepared (possibly shuffled) source list, the
+ * playback order, the loop flag and the current cursor.
+ */
+export interface SequencerState {
+  /** Prepared source list (shuffled once for `shuffle`, else original order). */
+  readonly sources: ReadonlyArray<PlaylistSource>;
+  /** Playback order (copied from the definition for convenience). */
+  readonly order: Order;
+  /** Loop flag (copied from the definition). */
+  readonly loop: boolean;
+  /** Cursor used by sequence/shuffle. Unused by random. */
+  readonly currentIndex: number;
+}
+
+/**
+ * Injectable RNG so tests are deterministic. Returns a float in [0, 1) just
+ * like `Math.random`. The default uses `Math.random`.
+ */
+export type Rng = () => number;
+
+const defaultRng: Rng = Math.random;
+
+/** Fisher–Yates shuffle over a copy (does not mutate the input). */
+function shuffled<T>(items: ReadonlyArray<T>, rng: Rng): T[] {
+  const out = items.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/**
+ * Build the initial sequencer state from a playlist definition.
+ * Mirrors `PlaylistRunner::new` + `prepare`.
+ *
+ * @param playlist - Playlist definition (not mutated).
+ * @param rng - Optional RNG used for the one-time shuffle.
+ */
+export function prepare(
+  playlist: Playlist,
+  rng: Rng = defaultRng
+): SequencerState {
+  // Only explicit sources are supported (generator is out of scope, matching
+  // the runner's TODO).
+  const explicit = playlist.sources ?? [];
+
+  const order = playlist.playback.order;
+  const sources =
+    order === "shuffle" ? shuffled(explicit, rng) : explicit.slice();
+
+  return {
+    sources,
+    order,
+    // `loop` defaults to true on the Rust side; the loader normalises it, but
+    // guard here too so a hand-built state is well-behaved.
+    loop: playlist.playback.loop,
+    currentIndex: 0,
+  };
+}
+
+/**
+ * The source the runner's `get_next()` would return for this state, *without*
+ * advancing. Returns `undefined` when there is nothing to show (empty list, or
+ * the sequence/shuffle cursor has run past the end with loop disabled).
+ *
+ * @param rng - Optional RNG used only for `random` order.
+ */
+export function getCurrent(
+  state: SequencerState,
+  rng: Rng = defaultRng
+): PlaylistSource | undefined {
+  if (state.sources.length === 0) {
+    return undefined;
+  }
+
+  if (state.order === "random") {
+    const index = Math.floor(rng() * state.sources.length);
+    return state.sources[index];
+  }
+
+  // sequence | shuffle: cursor-based. `undefined` once past the end.
+  return state.sources[state.currentIndex];
+}
+
+/**
+ * Advance the cursor, returning the next state. Mirrors the index bookkeeping
+ * `get_next()` performs after returning a source.
+ *
+ * - sequence/shuffle: `currentIndex += 1`, wrapping to 0 only when `loop` is
+ *   true. With loop disabled the index keeps climbing past the end so the next
+ *   `getCurrent()` yields `undefined` (= stop).
+ * - random: unchanged (random never advances a cursor, so it never stops —
+ *   this matches the Rust runner and is the documented behaviour, issue #20).
+ */
+export function advance(state: SequencerState): SequencerState {
+  if (state.sources.length === 0) {
+    return state;
+  }
+
+  if (state.order === "random") {
+    return state;
+  }
+
+  let nextIndex = state.currentIndex + 1;
+  if (nextIndex >= state.sources.length && state.loop) {
+    nextIndex = 0;
+  }
+
+  return { ...state, currentIndex: nextIndex };
+}
+
+/**
+ * Step the cursor backwards (UI affordance; the Rust runner has no `prev`, so
+ * this is a frontend-only convenience). sequence/shuffle move one slot back,
+ * wrapping to the last item when looping. random is left unchanged (its
+ * "current" is sampled fresh each render anyway).
+ */
+export function retreat(state: SequencerState): SequencerState {
+  if (state.sources.length === 0 || state.order === "random") {
+    return state;
+  }
+
+  let prevIndex = state.currentIndex - 1;
+  if (prevIndex < 0) {
+    prevIndex = state.loop ? state.sources.length - 1 : 0;
+  }
+
+  return { ...state, currentIndex: prevIndex };
+}
+
+/**
+ * Resolve the display duration (ms) for a source. Mirrors
+ * `PlaylistRunner::get_duration`:
+ * `source.duration ?? playback.defaultDuration ?? 5000`.
+ */
+export function durationFor(
+  source: PlaylistSource,
+  playback: Playlist["playback"]
+): number {
+  return (
+    source.duration ?? playback.defaultDuration ?? DEFAULT_SLIDE_DURATION_MS
+  );
+}
+
+/**
+ * Whether the slideshow has more to show. Mirrors
+ * `PlaylistRunner::should_continue`: empty → false; looping → always true;
+ * otherwise true until every item has been shown once.
+ */
+export function shouldContinue(state: SequencerState): boolean {
+  if (state.sources.length === 0) {
+    return false;
+  }
+  if (state.loop) {
+    return true;
+  }
+  return state.currentIndex < state.sources.length;
+}

--- a/frontend/src/lib/slideshowSequencer.ts
+++ b/frontend/src/lib/slideshowSequencer.ts
@@ -6,18 +6,24 @@
  * an explicit, immutable-ish state value so the ordering semantics can be unit
  * tested without React. `useSlideshow` wraps these in React state.
  *
- * Behaviour is intentionally identical to the Rust runner:
+ * Behaviour mirrors the Rust runner, with one documented difference for shuffle
+ * (the actual shuffle *order* is not reproduced — only set membership is):
  *
  * - prepare(): for `order === "shuffle"`, shuffle the sources **once**;
  *   `sequence` and `random` keep the source array as-is (random does NOT
- *   pre-shuffle — it samples each time).
+ *   pre-shuffle — it picks a fresh index per advance). Shuffle's resulting
+ *   order depends on the injected RNG, so it is only *membership-equivalent* to
+ *   the Rust runner, not order-identical (Rust uses its own `rand` shuffle).
  * - getCurrent(): the source the runner's `get_next()` would *return* for the
- *   current state. For sequence/shuffle that is `sources[currentIndex]`
- *   (`undefined` once the index has run past the end with loop disabled). For
- *   random it samples a uniformly random index each call.
+ *   current state. For every order this is `sources[currentIndex]` (`undefined`
+ *   once a sequence/shuffle cursor has run past the end with loop disabled).
+ *   getCurrent is pure: it never calls the RNG, so a slide cannot flicker
+ *   between renders.
  * - advance(): the index bookkeeping `get_next()` performs *after* returning a
  *   source. sequence/shuffle do `currentIndex += 1`, wrapping to 0 only when
- *   `loop` is true. random leaves the index untouched (so it never stops).
+ *   `loop` is true. random picks a fresh uniformly random `currentIndex` (so
+ *   every advance yields a new state — matching the Rust runner's "sample each
+ *   `get_next`" — and random never stops, issue #20).
  * - durationFor(): `source.duration ?? playback.defaultDuration ?? 5000`.
  *
  * Separation of concerns (doctrine 規律2): `Playlist` (definition) is never
@@ -97,42 +103,53 @@ export function prepare(
  * advancing. Returns `undefined` when there is nothing to show (empty list, or
  * the sequence/shuffle cursor has run past the end with loop disabled).
  *
- * @param rng - Optional RNG used only for `random` order.
+ * Pure: this never calls the RNG. For `random`, the next index is chosen in
+ * `advance()` and stored in `currentIndex`, so all orders read
+ * `sources[currentIndex]` here. Keeping the RNG out of render means a random
+ * slide stays put between renders and changes only on advance.
  */
 export function getCurrent(
-  state: SequencerState,
-  rng: Rng = defaultRng
+  state: SequencerState
 ): PlaylistSource | undefined {
   if (state.sources.length === 0) {
     return undefined;
   }
 
-  if (state.order === "random") {
-    const index = Math.floor(rng() * state.sources.length);
-    return state.sources[index];
-  }
-
-  // sequence | shuffle: cursor-based. `undefined` once past the end.
+  // All orders are cursor-based at read time. For sequence/shuffle the cursor
+  // may run past the end (=> `undefined` = stop); for random it always points
+  // at a valid in-range index chosen by prepare()/advance().
   return state.sources[state.currentIndex];
 }
 
 /**
- * Advance the cursor, returning the next state. Mirrors the index bookkeeping
- * `get_next()` performs after returning a source.
+ * Advance the cursor, returning the **next state** (always a new object when
+ * there is something to show, so React re-renders and re-arms the timer).
+ * Mirrors the index bookkeeping `get_next()` performs after returning a source.
  *
  * - sequence/shuffle: `currentIndex += 1`, wrapping to 0 only when `loop` is
  *   true. With loop disabled the index keeps climbing past the end so the next
  *   `getCurrent()` yields `undefined` (= stop).
- * - random: unchanged (random never advances a cursor, so it never stops —
- *   this matches the Rust runner and is the documented behaviour, issue #20).
+ * - random: pick a fresh uniformly random `currentIndex`. This is where the
+ *   RNG is consumed (not in `getCurrent`), so each advance yields a different
+ *   slide and a brand-new state. Random never advances "past the end", so it
+ *   never stops — matching the Rust runner and the documented behaviour, even
+ *   with `loop: false` (issue #20).
+ *
+ * @param rng - Optional RNG used only for `random` order.
  */
-export function advance(state: SequencerState): SequencerState {
+export function advance(
+  state: SequencerState,
+  rng: Rng = defaultRng
+): SequencerState {
   if (state.sources.length === 0) {
     return state;
   }
 
   if (state.order === "random") {
-    return state;
+    // Re-sample every advance (mirrors the Rust runner sampling per get_next).
+    // Always returns a new object so React never bails out of the update.
+    const nextIndex = Math.floor(rng() * state.sources.length);
+    return { ...state, currentIndex: nextIndex };
   }
 
   let nextIndex = state.currentIndex + 1;

--- a/frontend/src/lib/tauriCompat.ts
+++ b/frontend/src/lib/tauriCompat.ts
@@ -48,6 +48,11 @@ async function webFallback<T>(
       return loadPatternsListFromWeb() as T;
     }
 
+    case "load_playlist": {
+      const path = (args?.path as string) || "";
+      return loadPlaylistFromWeb(path) as T;
+    }
+
     case "get_calibration_status": {
       return {
         platform: "web",
@@ -116,6 +121,65 @@ async function loadPatternFromWeb(
   pattern = expandParams(pattern as any, _params) as Record<string, unknown>;
 
   return pattern;
+}
+
+/**
+ * Load a playlist file via fetch (web mode).
+ *
+ * The Tauri `load_playlist` command takes a filesystem `path`; in web mode we
+ * can't hit the filesystem, so we serve playlists from `public/playlists/` the
+ * same way patterns come from `public/patterns/`. The incoming `path` may be a
+ * bare name ("digital-signage"), a name with extension, or a relative/absolute
+ * path; we reduce it to `<name>` and fetch `/playlists/<name>.yaml` (falling
+ * back to `.json`).
+ *
+ * `loop` is defaulted to `true` to match the Rust serde `default_loop`, so a
+ * playlist whose YAML omits `loop` behaves identically in web and Tauri modes.
+ */
+async function loadPlaylistFromWeb(path: string): Promise<unknown> {
+  const { default: yaml } = await import("js-yaml");
+
+  // Reduce the path to a bare playlist name (strip dir + extension).
+  const fileName = path.replace(/\\/g, "/").split("/").pop() || path;
+  const name = fileName.replace(/\.(ya?ml|json)$/i, "");
+
+  // Try YAML first, then JSON.
+  const candidates = [
+    { url: `/playlists/${name}.yaml`, kind: "yaml" as const },
+    { url: `/playlists/${name}.json`, kind: "json" as const },
+  ];
+
+  let lastError = "";
+  for (const { url, kind } of candidates) {
+    const response = await fetch(url);
+    if (!response.ok) {
+      lastError = `${url} -> ${response.status}`;
+      continue;
+    }
+    const text = await response.text();
+    const parsed =
+      kind === "json"
+        ? (JSON.parse(text) as Record<string, unknown>)
+        : (yaml.load(text) as Record<string, unknown>);
+    return normalizePlaylist(parsed);
+  }
+
+  throw new Error(`Playlist not found: ${name} (${lastError})`);
+}
+
+/**
+ * Apply Rust-side serde defaults that aren't expressed in the raw file, so the
+ * web `Playlist` matches what the Tauri command would return.
+ */
+function normalizePlaylist(
+  raw: Record<string, unknown>
+): Record<string, unknown> {
+  const playback = (raw.playback as Record<string, unknown>) || {};
+  if (playback.loop === undefined) {
+    // serde `default_loop` => true.
+    playback.loop = true;
+  }
+  return { ...raw, playback };
 }
 
 /**

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
@@ -16,5 +17,10 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
   },
 });

--- a/playlists/digital-signage.yaml
+++ b/playlists/digital-signage.yaml
@@ -29,17 +29,20 @@ sources:
     path: "@/patterns/checker-with-dot.yaml"
     duration: 5000
 
-  # Random pattern (inline)
+  # Inline pattern (drawn directly from primitives the web renderer supports;
+  # `preset`/`background` are Rust-only and would render black on the web).
   - type: inline
     pattern:
       canvas:
         width: 1920
         height: 1080
       nodes:
+        # Full-frame solid fill via a rect primitive.
         - id: bg
-          type: background
-          preset: grayscale
-          params:
-            steps: 16
-            direction: horizontal
+          type: rect
+          x: 0
+          y: 0
+          width: 1920
+          height: 1080
+          fill: "#2E4053"
     duration: 10000


### PR DESCRIPTION
## 関連 Issue
closes #12（明示 sources の再生を配線）
- generator ソース（自動生成）は #21 に分離
- `set_pattern` Tauri command は現状の URL ナビ（`?pattern=`）で機能するため対象外

## 概要

runner(Rust) は完成済みだがフロントに再生機構が無く「動かない」状態だったスライドショーを、UI に配線した。pattern / image / url の3ソースに対応。

### 追加
- `frontend/src/lib/playlistTypes.ts` — 定義型（不変）。Rust `models.rs` と wire 一致（#16/#17 修正後の serde 形に合わせた）
- `frontend/src/lib/slideshowSequencer.ts` — **純粋シーケンサ**（`playlist/runner.rs` を鏡写し）。`Rng` 注入で random/shuffle を決定論化
- `frontend/src/hooks/useSlideshow.ts` — 実行時状態 + duration タイマー駆動（定義型は不変・規律2）
- `frontend/src/components/SlideshowView.tsx` — type 別描画（pattern=既存 NodeRenderer 再利用 / image=img / url=iframe）+ キー操作
- `frontend/src/lib/tauriCompat.ts` — `load_playlist` の web フォールバック（js-yaml で YAML/JSON パース）
- `frontend/src/App.tsx` — `?playlist=NAME` で SlideshowView、無ければ既存 `?pattern=` を維持（後方互換）
- vitest 基盤導入（フロント初のテスト基盤）+ `public/playlists/*.yaml`（web 供給）

### 挙動の一致（フロント ↔ Rust runner）
sequence は投入順 / shuffle は1回シャッフル後順次 / random は毎回乱択（loop と無関係に継続＝既知 #20）/ loop:false は全件後停止 / duration は `source.duration ?? defaultDuration ?? 5000`。

## テスト
`npm test`: **42 passed**（slideshowSequencer 26 + useSlideshow 14[fake timers] + smoke 2）。Rust `tests/golden_e2e.rs` の runner 系の鏡像。

## 検証メモ
- 自動検証: logic 42テスト緑 / 統合（dev サーバで mount・playlist 取得成功・canvas 生成・JSエラーなし）を確認。
- ヘッドレスでの自動ピクセル確認はこの環境では不可（待受 chrome 制約）。**実ブラウザでの目視サインオフは別途**（dev サーバ `?playlist=test-pattern-loop` 等）。