### PR TITLE
refactor: パターン定義型を不変明示し読込状態を PatternLoad に分離

### DIFF
--- a/frontend/src/components/PatternDisplay.tsx
+++ b/frontend/src/components/PatternDisplay.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import NodeRenderer from "./NodeRenderer";
 import PatternMenu from "./PatternMenu";
 import CalibrationSettings from "./CalibrationSettings";
-import type { XSGPattern } from "../lib/types";
+import type { PatternLoad, XSGPattern } from "../lib/types";
 
 interface PatternDisplayProps {
   pattern: string;
@@ -12,9 +12,10 @@ interface PatternDisplayProps {
 
 export default function PatternDisplay({ pattern }: PatternDisplayProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [patternData, setPatternData] = useState<XSGPattern | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // Runtime load state (規律2): the loaded `XSGPattern` is an immutable
+  // definition; loading/error live alongside it in this `PatternLoad` value
+  // rather than overloading the definition type as a state container.
+  const [load, setLoad] = useState<PatternLoad>({ status: "loading" });
 
   useEffect(() => {
     // Request fullscreen on mount
@@ -33,8 +34,7 @@ export default function PatternDisplay({ pattern }: PatternDisplayProps) {
 
   useEffect(() => {
     const loadPatternFile = async () => {
-      setLoading(true);
-      setError(null);
+      setLoad({ status: "loading" });
 
       try {
         // Map common pattern names to pattern IDs
@@ -89,12 +89,13 @@ export default function PatternDisplay({ pattern }: PatternDisplayProps) {
           params,
         })) as XSGPattern;
 
-        setPatternData(data);
+        setLoad({ status: "ready", pattern: data });
       } catch (err) {
         console.error("Failed to load pattern:", err);
-        setError(err instanceof Error ? err.message : "Failed to load pattern");
-      } finally {
-        setLoading(false);
+        setLoad({
+          status: "error",
+          message: err instanceof Error ? err.message : "Failed to load pattern",
+        });
       }
     };
 
@@ -102,7 +103,7 @@ export default function PatternDisplay({ pattern }: PatternDisplayProps) {
   }, [pattern]);
 
   const renderContent = () => {
-    if (loading) {
+    if (load.status === "loading") {
       return (
         <div className="w-full h-full flex items-center justify-center bg-black text-white">
           Loading pattern...
@@ -110,15 +111,15 @@ export default function PatternDisplay({ pattern }: PatternDisplayProps) {
       );
     }
 
-    if (error) {
+    if (load.status === "error") {
       return (
         <div className="w-full h-full flex items-center justify-center bg-black text-white">
-          Error: {error}
+          Error: {load.message}
         </div>
       );
     }
 
-    if (!patternData || !patternData.nodes) {
+    if (!load.pattern.nodes) {
       return (
         <div className="w-full h-full flex items-center justify-center bg-black text-white">
           No pattern data
@@ -128,7 +129,7 @@ export default function PatternDisplay({ pattern }: PatternDisplayProps) {
 
     return (
       <>
-        {patternData.nodes.map((node: any) => (
+        {load.pattern.nodes.map((node: any) => (
           <NodeRenderer key={node.id} node={node} />
         ))}
       </>

--- a/frontend/src/components/SlideshowView.tsx
+++ b/frontend/src/components/SlideshowView.tsx
@@ -5,7 +5,7 @@ import NodeRenderer from "./NodeRenderer";
 import { useSlideshow } from "../hooks/useSlideshow";
 import { resolvePath } from "../lib/pathResolver";
 import type { Playlist, PlaylistSource } from "../lib/playlistTypes";
-import type { XSGPattern } from "../lib/types";
+import type { PatternLoad, XSGPattern } from "../lib/types";
 
 interface SlideshowViewProps {
   /** Playlist name (e.g. "digital-signage") taken from `?playlist=`. */
@@ -169,38 +169,42 @@ function patternIdFromPath(path: string): string {
 
 /** Pattern source: load via get_pattern then render nodes (like PatternDisplay). */
 function PatternSlide({ path }: { path: string }) {
-  const [pattern, setPattern] = useState<XSGPattern | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  // Runtime load state (規律2): the loaded `XSGPattern` is an immutable
+  // definition; loading/error are held alongside it in `PatternLoad` instead of
+  // overloading the definition type as a state container.
+  const [load, setLoad] = useState<PatternLoad>({ status: "loading" });
 
   useEffect(() => {
     let cancelled = false;
-    const load = async () => {
-      setError(null);
-      setPattern(null);
+    const run = async () => {
+      setLoad({ status: "loading" });
       try {
         const { safeInvoke } = await import("../lib/tauriCompat");
         const data = await safeInvoke<XSGPattern>("get_pattern", {
           patternId: patternIdFromPath(path),
           params: {},
         });
-        if (!cancelled) setPattern(data);
+        if (!cancelled) setLoad({ status: "ready", pattern: data });
       } catch (err) {
         if (!cancelled) {
-          setError(
-            err instanceof Error ? err.message : "Failed to load pattern"
-          );
+          setLoad({
+            status: "error",
+            message:
+              err instanceof Error ? err.message : "Failed to load pattern",
+          });
         }
       }
     };
-    load();
+    run();
     return () => {
       cancelled = true;
     };
   }, [path]);
 
-  if (error) return <CenterMessage>Error: {error}</CenterMessage>;
-  if (!pattern || !pattern.nodes) return null;
-  return <PatternNodes pattern={pattern} />;
+  if (load.status === "error")
+    return <CenterMessage>Error: {load.message}</CenterMessage>;
+  if (load.status !== "ready" || !load.pattern.nodes) return null;
+  return <PatternNodes pattern={load.pattern} />;
 }
 
 /** Inline source: render the embedded pattern's nodes directly. */

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -318,18 +318,46 @@ export interface ParamDef {
 }
 
 /**
- * XSG Pattern definition
+ * XSG Pattern definition.
+ *
+ * This is the immutable *definition* type (規律2: 定義 vs 状態の分離). A loaded
+ * pattern is read-only data — it is never used as the container for runtime
+ * state (loading flags, the currently displayed slide, playback cursors, …).
+ * Runtime/loading state lives in separate `~State`/load types
+ * ({@link PatternLoad}, `SequencerState` in `slideshowSequencer.ts`).
+ *
+ * Pure transforms over patterns (`paramExpander.ts`: `expandParams`,
+ * `resolveExtends`) deep-clone or build a fresh object rather than mutating the
+ * input, so the fields are declared `readonly` to keep that contract honest.
  */
 export interface XSGPattern {
   /** Extends another pattern (template inheritance) */
-  extends?: string;
+  readonly extends?: string;
   /** Canvas dimensions */
-  canvas?: Canvas;
+  readonly canvas?: Canvas;
   /** Parameter definitions (optional, for template patterns) */
-  params?: Record<string, ParamDef>;
+  readonly params?: Record<string, ParamDef>;
   /** Array of nodes (layers), rendered in order (first = back, last = front) */
-  nodes?: PatternNode[];
+  readonly nodes?: PatternNode[];
 }
+
+// ============================================================================
+// Runtime State (NOT part of the definition)
+// ============================================================================
+
+/**
+ * Runtime load state for a pattern fetched via `get_pattern`.
+ *
+ * This is the `~State` companion to the {@link XSGPattern} definition: it is the
+ * mutable, per-component state of *loading* a pattern. Keeping it separate makes
+ * it explicit that the immutable definition ({@link XSGPattern}) is not reused as
+ * a state container (規律2). The loaded `pattern` is the definition; everything
+ * else here (status, error message) is runtime state.
+ */
+export type PatternLoad =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; pattern: XSGPattern };
 
 // ============================================================================
 // Legacy Format (for migration)


### PR DESCRIPTION
## 関連 Issue
closes #13

## 概要

dev-doctrine 規律2（定義データ vs 実行時状態の分離）の明示化。**最小修正**（+67/-34・3ファイル・挙動不変）。

- `XSGPattern`（定義型）のフィールドを `readonly` 化し「不変の定義・実行時状態の入れ物に流用しない」旨を doc 明示。`paramExpander` は deep clone / 新オブジェクト生成の純粋スタイルなので readonly 化でビルドは壊れない。
- 散在していた読込状態（loading/error/読込済みパターン）を discriminated union `PatternLoad = {status:"loading"} | {status:"error";message} | {status:"ready";pattern}` に集約（#12 の `~State` 作法に整合）。`PatternDisplay` と `SlideshowView`(PatternSlide) の useState を統合。描画分岐は従来と完全同一。

## スコープ外（最小主義）
- `XSGPattern→XSGPatternDef` のような大規模 rename はしない（低価値・高churn）。
- `SlideshowView` の playlist ローダーは `Playlist`（#12 で分離済みの定義型）であり #13 範囲外。

## テスト
`npm test`: 46 passed（挙動不変）。`npm run build` 型エラーなし。