### PR TITLE
fix: 座標式評価の eval() を安全な算術パーサに置換 (#4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build
 

--- a/frontend/src/lib/pathResolver.test.ts
+++ b/frontend/src/lib/pathResolver.test.ts
@@ -16,7 +16,7 @@
  * 網羅は後続の別スイートが担当する。
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { evaluateCoordinate } from "./pathResolver";
 
 // パーセント計算の基準となるコンテナサイズ。
@@ -100,6 +100,272 @@ describe("evaluateCoordinate — characterization golden (#4)", () => {
 
     it("空文字列は 0", () => {
       expect(evaluateCoordinate("", CONTAINER)).toBe(0);
+    });
+  });
+});
+
+/**
+ * pathResolver — 座標式評価の敵対的・エッジケーステスト（#4）。
+ *
+ * eval() を安全な算術パーサに置き換えたことを保証する追加スイート。
+ * characterization golden（上）が「正当入力の数値不変」を守るのに対し、
+ * こちらは「コード注入・構文崩れ・退化入力を安全側（=0）に倒す」ことを守る。
+ *
+ * すべて公開 API `evaluateCoordinate(coord, 1280)` 経由で検証する。
+ * injection payload は必ず `calc(<payload>)` でラップする。ラップしないと
+ * `parseCoordinate` の fallback（parseFloat）で素通りし、パーサに到達せず
+ * 無意味なテストになるため。
+ */
+describe("evaluateCoordinate — 敵対的・エッジケース（#4）", () => {
+  // A. injection 拒否 — 期待値はすべて 0、副作用ゼロ。
+  // 算術以外の識別子・記号・関数呼び出しはトークナイザが reject し 0 になる。
+  describe("A. injection 拒否（code injection を 0 に倒す）", () => {
+    it("A1 関数呼び出し alert(1) を実行せず 0 にする", () => {
+      expect(evaluateCoordinate("calc(alert(1))", CONTAINER)).toBe(0);
+    });
+
+    it("A2 プロトタイプ汚染入口 constructor を 0 にする", () => {
+      expect(evaluateCoordinate("calc(constructor)", CONTAINER)).toBe(0);
+    });
+
+    it("A3 グローバル参照 globalThis を 0 にする", () => {
+      expect(evaluateCoordinate("calc(globalThis)", CONTAINER)).toBe(0);
+    });
+
+    it("A4 Node グローバル process を 0 にする", () => {
+      expect(evaluateCoordinate("calc(process)", CONTAINER)).toBe(0);
+    });
+
+    it("A5 実行コンテキスト this を 0 にする", () => {
+      expect(evaluateCoordinate("calc(this)", CONTAINER)).toBe(0);
+    });
+
+    it("A6 文の連結 ';' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1;2)", CONTAINER)).toBe(0);
+    });
+
+    it("A7 カンマ演算子 ',' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1,2)", CONTAINER)).toBe(0);
+    });
+
+    it("A8 バッククォート（テンプレートリテラル混入）を 0 にする", () => {
+      // ソース内ではバッククォートを文字列リテラルとして渡す。
+      expect(evaluateCoordinate("calc(`1`)", CONTAINER)).toBe(0);
+    });
+
+    it("A9 テンプレ展開構文 ${1} を 0 にする", () => {
+      // 単一引用符で渡し、JS のテンプレ展開を発生させない。
+      expect(evaluateCoordinate("calc(${1})", CONTAINER)).toBe(0);
+    });
+
+    it("A10 16進数化せず 'x' を含む 0x10 を 0 にする", () => {
+      // '0' は数値、続く 'x' をトークナイザが拒否する。16進解釈はしない。
+      expect(evaluateCoordinate("calc(0x10)", CONTAINER)).toBe(0);
+    });
+
+    it("A11 指数表記化せず 'e' を含む 1e3 を 0 にする", () => {
+      // '1' は数値、続く 'e' を拒否する。指数解釈はしない。
+      expect(evaluateCoordinate("calc(1e3)", CONTAINER)).toBe(0);
+    });
+
+    it("A12 連続 '*'（べき乗 2**3）を 0 にする", () => {
+      expect(evaluateCoordinate("calc(2**3)", CONTAINER)).toBe(0);
+    });
+
+    it("A13 論理演算子 '&&' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1 && 1)", CONTAINER)).toBe(0);
+    });
+
+    it("A14 配列リテラル [] を 0 にする", () => {
+      expect(evaluateCoordinate("calc([])", CONTAINER)).toBe(0);
+    });
+
+    it("A14 オブジェクトリテラル {} を 0 にする", () => {
+      expect(evaluateCoordinate("calc({})", CONTAINER)).toBe(0);
+    });
+
+    it("A15 プロパティアクセス window.location を 0 にする", () => {
+      expect(evaluateCoordinate("calc(window.location)", CONTAINER)).toBe(0);
+    });
+
+    it("A16 px 除去後に alert(1) が残る pxalert(1) でも安全に 0 にする", () => {
+      // /px/g 除去で "alert(1)" になるが、'a' を拒否し評価しない。
+      expect(evaluateCoordinate("calc(pxalert(1))", CONTAINER)).toBe(0);
+    });
+  });
+
+  // B. 構文エラー — 算術トークンのみだが構造が破綻している入力を 0 に倒す。
+  describe("B. 構文エラー（壊れた算術式を 0 に倒す）", () => {
+    it("B1 末尾演算子 '1 +' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1 +)", CONTAINER)).toBe(0);
+    });
+
+    it("B2 先頭の二項演算子 '* 3' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(* 3)", CONTAINER)).toBe(0);
+    });
+
+    it("B3 演算子の連続 '1 +* 2' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1 +* 2)", CONTAINER)).toBe(0);
+    });
+
+    it("B4 閉じ括弧不足 '(1' を 0 にする", () => {
+      expect(evaluateCoordinate("calc((1)", CONTAINER)).toBe(0);
+    });
+
+    it("B5 余剰の閉じ括弧 '1)' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1))", CONTAINER)).toBe(0);
+    });
+
+    it("B6 空の括弧 '()' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(())", CONTAINER)).toBe(0);
+    });
+
+    it("B7 余剰トークン '1 2' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1 2)", CONTAINER)).toBe(0);
+    });
+
+    it("B8 括弧直後の余剰トークン '(1)2' を 0 にする", () => {
+      expect(evaluateCoordinate("calc((1)2)", CONTAINER)).toBe(0);
+    });
+
+    it("B9 二重小数点 '1.2.3' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1.2.3)", CONTAINER)).toBe(0);
+    });
+
+    it("B10 裸のドット '.' を 0 にする", () => {
+      expect(evaluateCoordinate("calc(.)", CONTAINER)).toBe(0);
+    });
+
+    it("B11 px 正規化後に空文字となる 'px' を 0 にする（空 expr 経路）", () => {
+      // "px" は /px/g 除去で "" になり、空トークン列としてパーサが reject する。
+      expect(evaluateCoordinate("calc(px)", CONTAINER)).toBe(0);
+    });
+
+    it("RC1 空括弧 'calc()' を 0 にする（parseCoordinate の /^calc\\((.+)\\)$/ に阻まれ別経路で 0。B11 の空 expr 経路とは別）", () => {
+      // calc() は中身が 0 文字なので calc 正規表現にマッチせず、fallback の
+      // parseFloat("calc()") = NaN → 0。パーサには到達しない。
+      expect(evaluateCoordinate("calc()", CONTAINER)).toBe(0);
+    });
+  });
+
+  // C. 数値セマンティクス — 純数 calc が JS 算術と一致する（精度・結合性）。
+  describe("C. 数値セマンティクス（JS 算術と一致）", () => {
+    it("C1 乗除が加減より先に束縛する 2 + 3 * 4 = 14", () => {
+      expect(evaluateCoordinate("calc(2 + 3 * 4)", CONTAINER)).toBe(14);
+    });
+
+    it("C2 括弧が優先順位を上書きする (2 + 3) * 4 = 20", () => {
+      expect(evaluateCoordinate("calc((2 + 3) * 4)", CONTAINER)).toBe(20);
+    });
+
+    it("C3 減算は左結合 10 - 3 - 2 = 5", () => {
+      expect(evaluateCoordinate("calc(10 - 3 - 2)", CONTAINER)).toBe(5);
+    });
+
+    it("C4 除算は左結合 100 / 10 / 2 = 5", () => {
+      expect(evaluateCoordinate("calc(100 / 10 / 2)", CONTAINER)).toBe(5);
+    });
+
+    it("C5 単項マイナスの連鎖 - - 5 = 5", () => {
+      expect(evaluateCoordinate("calc(- - 5)", CONTAINER)).toBe(5);
+    });
+
+    it("C6 二項減算と単項マイナスの混在 3 - -2 = 5", () => {
+      expect(evaluateCoordinate("calc(3 - -2)", CONTAINER)).toBe(5);
+    });
+
+    it("C7 単項プラス +5 = 5", () => {
+      expect(evaluateCoordinate("calc(+5)", CONTAINER)).toBe(5);
+    });
+
+    it("C8 深いネスト括弧 (((1 + 2))) = 3", () => {
+      expect(evaluateCoordinate("calc((((1 + 2))))", CONTAINER)).toBe(3);
+    });
+
+    it("C9 浮動小数の桁を固定 0.1 + 0.2 = 0.30000000000000004", () => {
+      expect(evaluateCoordinate("calc(0.1 + 0.2)", CONTAINER)).toBe(
+        0.30000000000000004
+      );
+    });
+
+    it("C10 複数項の優先順位 2 * 3 + 4 * 5 = 26", () => {
+      expect(evaluateCoordinate("calc(2 * 3 + 4 * 5)", CONTAINER)).toBe(26);
+    });
+  });
+
+  // D. 退化入力 — 旧 eval は Infinity/NaN を返したが、安全側で 0 に倒す意図仕様。
+  describe("D. 退化入力（旧 eval の Infinity/NaN を安全側で 0 に倒す意図仕様）", () => {
+    it("D-1 ゼロ除算 1 / 0 は Infinity でなく 0（安全側）", () => {
+      expect(evaluateCoordinate("calc(1 / 0)", CONTAINER)).toBe(0);
+    });
+
+    it("D-2 0/0 は NaN でなく 0（安全側）", () => {
+      expect(evaluateCoordinate("calc(0 / 0)", CONTAINER)).toBe(0);
+    });
+
+    it("D-3 Infinity を含む式 1 / 0 * 0 は NaN でなく 0（安全側）", () => {
+      expect(evaluateCoordinate("calc(1 / 0 * 0)", CONTAINER)).toBe(0);
+    });
+  });
+
+  // E. 数値トークナイザ境界 — 小数省略・末尾ドット・先頭ゼロ・px 融合。
+  describe("E. 数値トークナイザ境界", () => {
+    it("E1 整数部省略の小数 .5 + .5 = 1", () => {
+      expect(evaluateCoordinate("calc(.5 + .5)", CONTAINER)).toBe(1);
+    });
+
+    it("E2 末尾ドットの数値 12. + 0 = 12", () => {
+      expect(evaluateCoordinate("calc(12. + 0)", CONTAINER)).toBe(12);
+    });
+
+    it("E3 先頭ゼロを8進化しない 007 + 1 = 8", () => {
+      expect(evaluateCoordinate("calc(007 + 1)", CONTAINER)).toBe(8);
+    });
+
+    it("E4 px 融合で 1px2px が 12 に誤接合する既知挙動を固定", () => {
+      // /px/g 除去で "1px2px" → "12" になり 12 + 0 = 12。
+      // px 部分文字列の融合は現状仕様として pin する。
+      expect(evaluateCoordinate("calc(1px2px + 0)", CONTAINER)).toBe(12);
+    });
+  });
+
+  // F. 文字種混在・i18n — 全角数字・全角記号・絵文字は算術トークンでなく 0。
+  describe("F. 文字種混在・i18n（非 ASCII を 0 に倒す）", () => {
+    it("F1 全角数字 １２３ を 0 にする", () => {
+      expect(evaluateCoordinate("calc(１２３)", CONTAINER)).toBe(0);
+    });
+
+    it("F2 全角プラス 1＋2 を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1＋2)", CONTAINER)).toBe(0);
+    });
+
+    it("F3 絵文字混入 1 + 😀 を 0 にする", () => {
+      expect(evaluateCoordinate("calc(1 + 😀)", CONTAINER)).toBe(0);
+    });
+  });
+
+  // G. 横断的性質 — ログ汚染なし・状態の冪等性。
+  describe("G. 横断（ログ汚染なし・冪等）", () => {
+    it("G1 injection 評価でエラーログを出さない（console を汚染しない）", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      expect(evaluateCoordinate("calc(alert(1))", CONTAINER)).toBe(0);
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      logSpy.mockRestore();
+    });
+
+    it("G2 不正入力の直後でも正当入力が正しく評価される（pos/tokens を持ち越さない）", () => {
+      // 不正入力で内部状態（pos/tokens）が汚染されない冪等性を確認する。
+      expect(evaluateCoordinate("calc(1 2)", CONTAINER)).toBe(0);
+      expect(evaluateCoordinate("calc(2 + 3)", CONTAINER)).toBe(5);
     });
   });
 });

--- a/frontend/src/lib/pathResolver.test.ts
+++ b/frontend/src/lib/pathResolver.test.ts
@@ -1,0 +1,105 @@
+/**
+ * pathResolver — 座標式評価の characterization golden（#4）。
+ *
+ * これは `evaluateCoordinate()` の「現状挙動」をリテラルで固定するための回帰スイートである。
+ * 目的は `evaluateCalcExpression()` 内部の `eval()` を安全な算術評価器に置き換える前後で
+ * 数値出力が一切変わらないことを機械検証すること（characterization-first）。
+ *
+ * 方針:
+ *   - 非公開の `evaluateCalcExpression` を export して直接叩くのではなく、公開 API
+ *     `evaluateCoordinate(coord, containerSize)` 経由でのみ検証する。
+ *   - golden 値は eval() ベースの現行実装の実出力に厳密に合わせる（浮動小数の桁も含む）。
+ *   - 代表 containerSize として 1280 を用いる（パーセント計算の基準）。
+ *
+ * ここで扱うのは「正当な入力」の golden のみ。injection 拒否・敵対的入力・パーサの
+ * エッジケース（英字/関数呼び出し/`;`/深いネスト/ゼロ除算/演算子の連続/末尾演算子 等）の
+ * 網羅は後続の別スイートが担当する。
+ */
+
+import { describe, expect, it } from "vitest";
+import { evaluateCoordinate } from "./pathResolver";
+
+// パーセント計算の基準となるコンテナサイズ。
+const CONTAINER = 1280;
+
+describe("evaluateCoordinate — characterization golden (#4)", () => {
+  describe("absolute（number 入力）", () => {
+    it("整数の絶対値はそのまま返す", () => {
+      expect(evaluateCoordinate(100, CONTAINER)).toBe(100);
+    });
+
+    it("0 はそのまま返す", () => {
+      expect(evaluateCoordinate(0, CONTAINER)).toBe(0);
+    });
+
+    it("小数の絶対値はそのまま返す", () => {
+      expect(evaluateCoordinate(1920.5, CONTAINER)).toBe(1920.5);
+    });
+  });
+
+  describe("percentage（'N%' 入力）", () => {
+    it("0% は 0", () => {
+      expect(evaluateCoordinate("0%", CONTAINER)).toBe(0);
+    });
+
+    it("50% は containerSize の半分", () => {
+      expect(evaluateCoordinate("50%", CONTAINER)).toBe(640);
+    });
+
+    it("100% は containerSize そのもの", () => {
+      expect(evaluateCoordinate("100%", CONTAINER)).toBe(1280);
+    });
+
+    it("小数パーセント 33.3% は浮動小数のまま（桁を固定）", () => {
+      expect(evaluateCoordinate("33.3%", CONTAINER)).toBe(426.23999999999995);
+    });
+  });
+
+  describe("calc（四則演算）", () => {
+    it("calc(50% + 10px) = 640 + 10", () => {
+      expect(evaluateCoordinate("calc(50% + 10px)", CONTAINER)).toBe(650);
+    });
+
+    it("calc(50% - 10px) = 640 - 10", () => {
+      expect(evaluateCoordinate("calc(50% - 10px)", CONTAINER)).toBe(630);
+    });
+
+    it("calc(50% * 2) = 640 * 2", () => {
+      expect(evaluateCoordinate("calc(50% * 2)", CONTAINER)).toBe(1280);
+    });
+
+    it("calc(100% / 2) = 1280 / 2", () => {
+      expect(evaluateCoordinate("calc(100% / 2)", CONTAINER)).toBe(640);
+    });
+  });
+
+  describe("calc（ネスト括弧）", () => {
+    it("calc((50% + 10px) / 2) = (640 + 10) / 2", () => {
+      expect(evaluateCoordinate("calc((50% + 10px) / 2)", CONTAINER)).toBe(325);
+    });
+  });
+
+  describe("calc（小数混在）", () => {
+    it("calc(33.3% + 0.5px) は浮動小数のまま（桁を固定）", () => {
+      expect(evaluateCoordinate("calc(33.3% + 0.5px)", CONTAINER)).toBe(
+        426.73999999999995
+      );
+    });
+  });
+
+  describe("calc（負値になるケース）", () => {
+    it("calc(10px - 50%) = 10 - 640 = -630", () => {
+      expect(evaluateCoordinate("calc(10px - 50%)", CONTAINER)).toBe(-630);
+    });
+  });
+
+  describe("フォールバック（parseCoordinate が absolute 0 になる経路）", () => {
+    it("数値化できない文字列は 0", () => {
+      expect(evaluateCoordinate("abc", CONTAINER)).toBe(0);
+    });
+
+    it("空文字列は 0", () => {
+      expect(evaluateCoordinate("", CONTAINER)).toBe(0);
+    });
+  });
+});

--- a/frontend/src/lib/pathResolver.test.ts
+++ b/frontend/src/lib/pathResolver.test.ts
@@ -368,4 +368,22 @@ describe("evaluateCoordinate — 敵対的・エッジケース（#4）", () => 
       expect(evaluateCoordinate("calc(2 + 3)", CONTAINER)).toBe(5);
     });
   });
+
+  // H. DoS 耐性 — 病的に深いネスト括弧でも throw せず 0 に倒す。
+  // 現状は再帰下降パーサが stack overflow（RangeError）を投げ、末尾の
+  // try/catch がそれを握って 0 を返すことで成立する。将来 iterative parser 等に
+  // リファクタしても「病的ネスト → 例外を外に漏らさず 0」が回帰しないよう固定する。
+  describe("H. DoS 耐性（病的に深いネストでも throw せず 0）", () => {
+    it("H1 深いネストでも throw せず 0（DoS 耐性）", () => {
+      // 10 万重のネスト括弧。再帰下降が stack overflow しても
+      // 公開 API は例外を外に漏らさず 0 を返し切ることを固定する。
+      const coord =
+        "calc(" + "(".repeat(100000) + "1" + ")".repeat(100000) + ")";
+      let result: number | undefined;
+      expect(() => {
+        result = evaluateCoordinate(coord, CONTAINER);
+      }).not.toThrow();
+      expect(result).toBe(0);
+    });
+  });
 });

--- a/frontend/src/lib/pathResolver.ts
+++ b/frontend/src/lib/pathResolver.ts
@@ -353,7 +353,10 @@ function evaluateCalcExpression(expr: string, containerSize: number): number {
  * `* /` bind tighter than `+ -`, operators are left-associative, and unary
  * minus is supported. On any tokenization/parse failure (unknown character,
  * empty or incomplete expression, etc.) this returns 0, matching the old
- * `catch { return 0 }` behavior.
+ * `catch { return 0 }` behavior. Separately, a *successful* parse whose result
+ * is non-finite (e.g. div-by-zero → Infinity, 0/0 → NaN) is also coerced to 0;
+ * that is an intentional safety divergence from the old eval (which surfaced
+ * Infinity/NaN), not the same path as a parse failure.
  *
  * @param expr - Normalized arithmetic expression (no units, no percentages)
  * @returns Evaluated value, or 0 if the expression is invalid

--- a/frontend/src/lib/pathResolver.ts
+++ b/frontend/src/lib/pathResolver.ts
@@ -84,7 +84,7 @@ export class PathResolver {
    */
   private isAbsolutePath(path: string): boolean {
     // Windows absolute paths
-    if (/^[a-zA-Z]:[\\\/]/.test(path)) return true;
+    if (/^[a-zA-Z]:[\\/]/.test(path)) return true;
     if (/^\\\\/.test(path)) return true; // UNC paths
 
     // Unix absolute paths
@@ -335,11 +335,190 @@ function evaluateCalcExpression(expr: string, containerSize: number): number {
   // Remove 'px' units
   const withoutUnits = normalized.replace(/px/g, "");
 
-  // Evaluate expression (simple evaluation, not production-ready)
-  // For production, consider using a proper expression parser
+  // Evaluate the now purely-arithmetic expression with a sandboxed parser.
+  // This intentionally avoids eval()/Function so that a hostile pattern file
+  // cannot inject code through coordinate expressions.
+  return evaluateArithmetic(withoutUnits);
+}
+
+/**
+ * Safely evaluate a pure arithmetic expression to a number.
+ *
+ * This replaces the previous eval()-based evaluation to remove the code
+ * injection risk: only numbers, the binary operators `+ - * /`, unary `+`/`-`,
+ * parentheses, and whitespace are accepted. Any identifier, function call,
+ * or stray symbol causes the whole expression to be rejected.
+ *
+ * Numeric semantics match JavaScript arithmetic: floating-point division,
+ * `* /` bind tighter than `+ -`, operators are left-associative, and unary
+ * minus is supported. On any tokenization/parse failure (unknown character,
+ * empty or incomplete expression, etc.) this returns 0, matching the old
+ * `catch { return 0 }` behavior.
+ *
+ * @param expr - Normalized arithmetic expression (no units, no percentages)
+ * @returns Evaluated value, or 0 if the expression is invalid
+ */
+function evaluateArithmetic(expr: string): number {
+  type Token =
+    | { kind: "number"; value: number }
+    | { kind: "op"; value: "+" | "-" | "*" | "/" }
+    | { kind: "lparen" }
+    | { kind: "rparen" };
+
+  // --- Tokenizer ---------------------------------------------------------
+  const tokenize = (input: string): Token[] | null => {
+    const tokens: Token[] = [];
+    let i = 0;
+
+    while (i < input.length) {
+      const ch = input[i];
+
+      // Whitespace is ignored.
+      if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+        i++;
+        continue;
+      }
+
+      // Numbers: integer or decimal (e.g. "640", "0.5", ".5", "12.").
+      if ((ch >= "0" && ch <= "9") || ch === ".") {
+        let j = i;
+        let seenDot = false;
+        while (j < input.length) {
+          const c = input[j];
+          if (c >= "0" && c <= "9") {
+            j++;
+          } else if (c === "." && !seenDot) {
+            seenDot = true;
+            j++;
+          } else {
+            break;
+          }
+        }
+        const slice = input.slice(i, j);
+        const value = Number(slice);
+        // Guard against malformed numbers like a bare ".".
+        if (!Number.isFinite(value)) {
+          return null;
+        }
+        tokens.push({ kind: "number", value });
+        i = j;
+        continue;
+      }
+
+      if (ch === "+" || ch === "-" || ch === "*" || ch === "/") {
+        tokens.push({ kind: "op", value: ch });
+        i++;
+        continue;
+      }
+
+      if (ch === "(") {
+        tokens.push({ kind: "lparen" });
+        i++;
+        continue;
+      }
+
+      if (ch === ")") {
+        tokens.push({ kind: "rparen" });
+        i++;
+        continue;
+      }
+
+      // Anything else (letters, ';', ',', etc.) is rejected outright.
+      return null;
+    }
+
+    return tokens;
+  };
+
+  // --- Recursive-descent parser ------------------------------------------
+  // Grammar (left-associative, standard precedence):
+  //   expression := term (('+' | '-') term)*
+  //   term       := factor (('*' | '/') factor)*
+  //   factor     := ('+' | '-') factor | '(' expression ')' | number
+  const tokens = tokenize(expr);
+  if (tokens === null) {
+    return 0;
+  }
+
+  let pos = 0;
+  const peek = (): Token | undefined => tokens[pos];
+
+  // ParseError sentinel: thrown on any structural problem, caught below.
+  class ParseError extends Error {}
+
+  const parseFactor = (): number => {
+    const token = peek();
+    if (token === undefined) {
+      throw new ParseError("unexpected end of expression");
+    }
+
+    // Unary +/-
+    if (token.kind === "op" && (token.value === "+" || token.value === "-")) {
+      pos++;
+      const operand = parseFactor();
+      return token.value === "-" ? -operand : operand;
+    }
+
+    if (token.kind === "lparen") {
+      pos++;
+      const value = parseExpression();
+      const closing = peek();
+      if (closing === undefined || closing.kind !== "rparen") {
+        throw new ParseError("missing closing parenthesis");
+      }
+      pos++;
+      return value;
+    }
+
+    if (token.kind === "number") {
+      pos++;
+      return token.value;
+    }
+
+    throw new ParseError("expected number or '('");
+  };
+
+  const parseTerm = (): number => {
+    let value = parseFactor();
+    for (;;) {
+      const token = peek();
+      if (token === undefined || token.kind !== "op") {
+        break;
+      }
+      if (token.value !== "*" && token.value !== "/") {
+        break;
+      }
+      pos++;
+      const right = parseFactor();
+      value = token.value === "*" ? value * right : value / right;
+    }
+    return value;
+  };
+
+  const parseExpression = (): number => {
+    let value = parseTerm();
+    for (;;) {
+      const token = peek();
+      if (token === undefined || token.kind !== "op") {
+        break;
+      }
+      if (token.value !== "+" && token.value !== "-") {
+        break;
+      }
+      pos++;
+      const right = parseTerm();
+      value = token.value === "+" ? value + right : value - right;
+    }
+    return value;
+  };
+
   try {
-    // eslint-disable-next-line no-eval
-    return eval(withoutUnits);
+    const result = parseExpression();
+    // Reject trailing garbage (e.g. "1 2" or "(1)2").
+    if (pos !== tokens.length) {
+      return 0;
+    }
+    return Number.isFinite(result) ? result : 0;
   } catch {
     return 0;
   }


### PR DESCRIPTION
## 関連 Issue
closes #4

## 背景
YAML パターン定義の座標式 `calc(...)` 評価に `eval()` を使用しており、悪意あるパターンファイルを読み込んだ場合にコード注入が可能だった（`frontend/src/lib/pathResolver.ts` の `evaluateCalcExpression`）。

## 変更内容（characterization-first / #11 と同じ作法）
1. **characterization golden を先に敷く**（`pathResolver.test.ts` 新規16件）— 正当な `calc` 四則・`%`・小数・ネストの現状出力（eval ベース）を厳密にリテラル固定。
2. **eval() を安全な算術パーサ `evaluateArithmetic` に置換** — 数値・`+ - * /`・単項符号・括弧・空白のみを受理する再帰下降パーサ。識別子・関数呼び出し・記号はトークン化段階で拒否。優先順位 `*/` > `+-`、左結合、浮動小数除算で JS 算術と一致。`eslint-disable no-eval` を削除。
3. **characterization が緑のまま通ることを機械検証**（挙動不変）。
4. **敵対的・エッジケーステスト51件追加** — injection 拒否（`alert(1)`/`constructor`/`globalThis`/`0x10`/`1e3`/テンプレリテラル等が全て 0・副作用ゼロ）、構文エラー→0、数値セマンティクス一致、トークナイザ境界、i18n、ログ汚染・冪等。
5. **フロント vitest を CI ゲートに追加**（従来 build のみで未ゲートだった）。

## 意図的な仕様変更（PR レビュー注記）
- **ゼロ除算 `1/0` / 不定 `0/0` → 0**（旧 eval は Infinity/NaN）。`Number.isFinite` ガードで安全側に倒した。座標評価器として Infinity/NaN は不正な座標になるため 0 が正しい。正当パターンはこの経路を踏まない（golden 16件に影響なし）。
- **`px` 部分文字列除去の既知挙動**: `calc(1px2px)` → `12`（px 融合）。現状仕様として characterization 固定。実害は薄い（座標式に px を2つ書く用途がない）。

## 対象外
- `evaluateCoordinate(null/undefined)` の TypeError は本修正のスコープ外（実装未変更）。

## テスト
- `npm test`: 113 passed（pathResolver 67 + slideshow 系 46）。
- docs: calc() スキーマ説明（`schema-orthogonality.md`）は引き続き正確、eval() への言及は元から無いため更新不要。