### PR TITLE
refactor: lib.rs と PatternDisplay.tsx の責務分解 (#14)

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -4,16 +4,15 @@ pub mod pattern_expander;
 mod pattern_loader;
 pub mod patterns;
 pub mod playlist;
+mod window_manager;
 
 use calibration::{CalibrationStatus, ControlResult};
-use displays::{print_display_list, select_displays, DisplayInfo};
 use pattern_loader::load_pattern_with_params;
 use patterns::{load_patterns, PatternsResponse};
 use playlist::Playlist;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
 /// Tauri command: Get all available patterns
 #[tauri::command]
@@ -81,41 +80,7 @@ pub fn run(pattern: String, display_spec: String, list_displays: bool) {
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(
             move |app, args, _cwd| {
-                // This callback is triggered when a second instance is launched
-                log::info!(
-                    "Single instance: Another instance attempted to start with args: {args:?}"
-                );
-
-                // If args contain --pattern, switch to that pattern
-                if let Some(pattern_arg_idx) = args.iter().position(|arg| arg == "--pattern") {
-                    if let Some(new_pattern) = args.get(pattern_arg_idx + 1) {
-                        log::info!("Switching to pattern: {new_pattern}");
-
-                        // Switch pattern on all display windows by navigating to new URL
-                        for i in 0..8 {
-                            let window_label = format!("display-{i}");
-                            if let Some(window) = app.get_webview_window(&window_label) {
-                                let url = if cfg!(debug_assertions) {
-                                    format!("http://localhost:3000/?pattern={new_pattern}")
-                                } else {
-                                    format!("tauri://localhost/?pattern={new_pattern}")
-                                };
-                                let js = format!(
-                                    "window.location.href = '{}';",
-                                    url.replace('\'', "\\'")
-                                );
-                                let _ = window.eval(&js);
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                // Bring existing windows to front
-                if let Some(window) = app.get_webview_window("display-0") {
-                    let _ = window.set_focus();
-                }
+                window_manager::handle_second_instance(app, args);
             },
         ))
         .setup(move |app| {
@@ -127,73 +92,7 @@ pub fn run(pattern: String, display_spec: String, list_displays: bool) {
                 )?;
             }
 
-            // Get available monitors
-            let monitors = app.available_monitors()?;
-            let primary_monitor = app.primary_monitor()?.expect("No primary monitor found");
-
-            // Convert monitors to DisplayInfo
-            let all_displays: Vec<DisplayInfo> = monitors
-                .iter()
-                .enumerate()
-                .map(|(i, m)| {
-                    let is_primary = m.name() == primary_monitor.name();
-                    DisplayInfo::from_monitor(m, i, is_primary)
-                })
-                .collect();
-
-            // If --list-displays, print and exit
-            if list_displays {
-                print_display_list(&all_displays);
-                std::process::exit(0);
-            }
-
-            // Select displays based on specification
-            let selected_displays = select_displays(&display_spec, &all_displays);
-
-            if selected_displays.is_empty() {
-                eprintln!("[ERROR] No displays selected with spec: {display_spec}");
-                std::process::exit(1);
-            }
-
-            // Build URL with pattern parameter
-            let url = if cfg!(debug_assertions) {
-                format!("http://localhost:3000/?pattern={pattern}")
-            } else {
-                format!("tauri://localhost/?pattern={pattern}")
-            };
-
-            // Get the default window (created by tauri.conf.json)
-            // We'll close it and create new ones for each display
-            if let Some(main_window) = app.get_webview_window("main") {
-                main_window.close()?;
-            }
-
-            // Create a window for each selected display
-            for (i, display) in selected_displays.iter().enumerate() {
-                let window_label = format!("display-{i}");
-
-                WebviewWindowBuilder::new(
-                    app,
-                    &window_label,
-                    WebviewUrl::External(url.parse().unwrap()),
-                )
-                .position(display.x as f64, display.y as f64)
-                .inner_size(display.width as f64, display.height as f64)
-                .resizable(false)
-                .fullscreen(false) // We manually set size to display size
-                .decorations(false)
-                .build()?;
-
-                log::info!(
-                    "Created window {} on display {} ({}x{} at {},{})",
-                    window_label,
-                    display.name,
-                    display.width,
-                    display.height,
-                    display.x,
-                    display.y
-                );
-            }
+            window_manager::setup_windows(app, &pattern, &display_spec, list_displays)?;
 
             Ok(())
         })

--- a/frontend/src-tauri/src/window_manager.rs
+++ b/frontend/src-tauri/src/window_manager.rs
@@ -1,0 +1,151 @@
+//! ウィンドウ生成・setup・URL ビルダーを集約するモジュール。
+//!
+//! `lib.rs` は Tauri command 定義と `run()` のプラグイン/ハンドラ配線に専念し、
+//! 「どのモニタにどんな URL のウィンドウを立てるか」という window のライフサイクルは
+//! ここに寄せる（単一責務）。display の**選択**ロジック自体は `displays.rs`
+//! （`select_displays` / `print_display_list` / `DisplayInfo`）のままで、ここはそれを
+//! 呼び出して app にウィンドウを生成する側に徹する。
+
+use crate::displays::{print_display_list, select_displays, DisplayInfo};
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+
+/// パターン名から表示用 URL を組み立てる単一ヘルパ。
+///
+/// dev（`debug_assertions`）では Vite dev サーバー、prod では `tauri://localhost` を指す。
+/// この分岐とクエリ整形は lib.rs の2箇所（second-instance のパターン切替・初回 setup）に
+/// 重複していたものをここへ集約したもの。挙動は元と完全一致させる。
+pub(crate) fn pattern_url(pattern: &str) -> String {
+    if cfg!(debug_assertions) {
+        format!("http://localhost:3000/?pattern={pattern}")
+    } else {
+        format!("tauri://localhost/?pattern={pattern}")
+    }
+}
+
+/// app の利用可能モニタを列挙して `DisplayInfo` のベクタに変換する。
+///
+/// primary 判定は `primary_monitor()` の name 一致で行う（元の setup ロジックそのまま）。
+fn collect_displays(app: &tauri::App) -> tauri::Result<Vec<DisplayInfo>> {
+    let monitors = app.available_monitors()?;
+    let primary_monitor = app.primary_monitor()?.expect("No primary monitor found");
+
+    Ok(monitors
+        .iter()
+        .enumerate()
+        .map(|(i, m)| {
+            let is_primary = m.name() == primary_monitor.name();
+            DisplayInfo::from_monitor(m, i, is_primary)
+        })
+        .collect())
+}
+
+/// setup フェーズ本体: モニタ列挙 → DisplayInfo 変換 → list_displays 分岐 →
+/// select_displays → 空チェック → main window close → ウィンドウ生成ループ。
+///
+/// `--list-displays` 指定時は一覧を print して `exit(0)`、選択が空なら `exit(1)`。
+/// `std::process::exit` の挙動・ログ出力・エラー伝播は lib.rs にあった元実装のまま。
+pub(crate) fn setup_windows(
+    app: &mut tauri::App,
+    pattern: &str,
+    display_spec: &str,
+    list_displays: bool,
+) -> tauri::Result<()> {
+    // Get available monitors and convert to DisplayInfo
+    let all_displays = collect_displays(app)?;
+
+    // If --list-displays, print and exit
+    if list_displays {
+        print_display_list(&all_displays);
+        std::process::exit(0);
+    }
+
+    // Select displays based on specification
+    let selected_displays = select_displays(display_spec, &all_displays);
+
+    if selected_displays.is_empty() {
+        eprintln!("[ERROR] No displays selected with spec: {display_spec}");
+        std::process::exit(1);
+    }
+
+    // Build URL with pattern parameter
+    let url = pattern_url(pattern);
+
+    // Get the default window (created by tauri.conf.json)
+    // We'll close it and create new ones for each display
+    if let Some(main_window) = app.get_webview_window("main") {
+        main_window.close()?;
+    }
+
+    // Create a window for each selected display
+    for (i, display) in selected_displays.iter().enumerate() {
+        let window_label = format!("display-{i}");
+
+        WebviewWindowBuilder::new(
+            app,
+            &window_label,
+            WebviewUrl::External(url.parse().unwrap()),
+        )
+        .position(display.x as f64, display.y as f64)
+        .inner_size(display.width as f64, display.height as f64)
+        .resizable(false)
+        .fullscreen(false) // We manually set size to display size
+        .decorations(false)
+        .build()?;
+
+        log::info!(
+            "Created window {} on display {} ({}x{} at {},{})",
+            window_label,
+            display.name,
+            display.width,
+            display.height,
+            display.x,
+            display.y
+        );
+    }
+
+    Ok(())
+}
+
+/// single-instance プラグインのコールバック本体。
+///
+/// 2つ目のインスタンスが起動したときに呼ばれる。`--pattern <name>` があればその
+/// パターンへ全 display ウィンドウを切り替え、最後に既存ウィンドウを前面に出す。
+pub(crate) fn handle_second_instance<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    args: Vec<String>,
+) {
+    // This callback is triggered when a second instance is launched
+    log::info!("Single instance: Another instance attempted to start with args: {args:?}");
+
+    // If args contain --pattern, switch to that pattern
+    if let Some(pattern_arg_idx) = args.iter().position(|arg| arg == "--pattern") {
+        if let Some(new_pattern) = args.get(pattern_arg_idx + 1) {
+            log::info!("Switching to pattern: {new_pattern}");
+            switch_pattern(app, new_pattern);
+        }
+    }
+
+    // Bring existing windows to front
+    if let Some(window) = app.get_webview_window("display-0") {
+        let _ = window.set_focus();
+    }
+}
+
+/// 全 display ウィンドウ（最大8枚）を新パターンの URL へ `location.href` 書換で遷移させる。
+///
+/// `display-{i}` を 0 から走査し、存在しないラベルに当たった時点で break する
+/// （元実装と同じ早期終了）。URL は `pattern_url` で組み立て、シングルクォートを
+/// エスケープしてから `window.eval` で実行する。
+fn switch_pattern<R: tauri::Runtime>(app: &tauri::AppHandle<R>, new_pattern: &str) {
+    // Switch pattern on all display windows by navigating to new URL
+    for i in 0..8 {
+        let window_label = format!("display-{i}");
+        if let Some(window) = app.get_webview_window(&window_label) {
+            let url = pattern_url(new_pattern);
+            let js = format!("window.location.href = '{}';", url.replace('\'', "\\'"));
+            let _ = window.eval(&js);
+        } else {
+            break;
+        }
+    }
+}

--- a/frontend/src/components/PatternCanvas.test.tsx
+++ b/frontend/src/components/PatternCanvas.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * PatternCanvas — PatternLoad の状態に応じて描画を出し分ける表示層のテスト。
+ *
+ * Issue #14 で `PatternDisplay.renderContent` から切り出したプレゼンテーショナル
+ * コンポーネント。抽出が将来壊れないよう、4分岐の出し分けと nodes の map を固定する。
+ * 守る挙動:
+ *   - status:loading → "Loading pattern..."
+ *   - status:error → "Error: {message}"（message を表示）
+ *   - status:ready かつ pattern.nodes 無し → "No pattern data"
+ *   - status:ready かつ nodes 配列 → NodeRenderer を node 件数ぶん描画（key=node.id）
+ *
+ * NodeRenderer の中身（Canvas 2D 描画）は本テストの対象外なので vi.mock でスタブ化し、
+ * 「いくつ描画されたか・どの node に対してか」だけを観測する。jsdom に jest-dom
+ * セットアップは無いので、素の DOM（screen.getByText / querySelectorAll）で assert する。
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PatternCanvas from "./PatternCanvas";
+import type { PatternLoad, PatternNode } from "../lib/types";
+
+// NodeRenderer をスタブ化：受け取った node.id を data 属性に持つマーカー要素にする。
+// 分岐レンダリングの検証が目的なので、実描画（canvas）には依存させない。
+vi.mock("./NodeRenderer", () => ({
+  default: ({ node }: { node: PatternNode }) => (
+    <div data-testid="node" data-node-id={node.id} />
+  ),
+}));
+
+/** rect ノードを id 指定で作る最小ヘルパ。 */
+function rectNode(id: string): PatternNode {
+  return { id, type: "rect", x: 0, y: 0, width: 10, height: 10 };
+}
+
+// ---------------------------------------------------------------------------
+describe("PatternCanvas", () => {
+  it("loading 状態で 'Loading pattern...' を表示する", () => {
+    // --- 仕様: status:loading は読込中文言を出す ---
+    const load: PatternLoad = { status: "loading" };
+    render(<PatternCanvas load={load} />);
+    expect(screen.getByText("Loading pattern...")).toBeTruthy();
+  });
+
+  it("error 状態で load.message を表示する", () => {
+    // --- 仕様: status:error は "Error: {message}" を出す（message を埋める）---
+    const load: PatternLoad = { status: "error", message: "boom happened" };
+    render(<PatternCanvas load={load} />);
+    // message がそのまま画面に出ていること。
+    expect(screen.getByText(/boom happened/)).toBeTruthy();
+    expect(screen.getByText(/^Error:/)).toBeTruthy();
+  });
+
+  it("ready かつ nodes 無しで 'No pattern data' を表示する", () => {
+    // --- 仕様: 読込成功だが pattern.nodes が未定義なら no-data 文言を出す ---
+    const load: PatternLoad = {
+      status: "ready",
+      pattern: { canvas: { width: 100, height: 100 } }, // nodes 無し
+    };
+    render(<PatternCanvas load={load} />);
+    expect(screen.getByText("No pattern data")).toBeTruthy();
+    // ノードは1つも描画されない。
+    expect(screen.queryAllByTestId("node")).toHaveLength(0);
+  });
+
+  it("ready かつ nodes 2件で NodeRenderer を2つ描画する", () => {
+    // --- 仕様: status:ready かつ nodes 配列は各 node を NodeRenderer に map する ---
+    const nodes = [rectNode("n1"), rectNode("n2")];
+    const load: PatternLoad = {
+      status: "ready",
+      pattern: { nodes },
+    };
+    render(<PatternCanvas load={load} />);
+
+    const rendered = screen.getAllByTestId("node");
+    expect(rendered).toHaveLength(2);
+    // 各 node の id がそのまま渡っている（key=node.id で map している証跡）。
+    expect(rendered.map((el) => el.getAttribute("data-node-id"))).toEqual([
+      "n1",
+      "n2",
+    ]);
+    // no-data / loading 文言は出ない。
+    expect(screen.queryByText("No pattern data")).toBeNull();
+    expect(screen.queryByText("Loading pattern...")).toBeNull();
+  });
+
+  it("ready かつ nodes 空配列は no-data ではなく 0 件描画になる", () => {
+    // --- 仕様: nodes が [] のときは「存在する空配列」なので no-data 分岐に入らず、
+    //          map 結果が 0 件になる（!load.pattern.nodes は false）---
+    const load: PatternLoad = { status: "ready", pattern: { nodes: [] } };
+    render(<PatternCanvas load={load} />);
+    expect(screen.queryByText("No pattern data")).toBeNull();
+    expect(screen.queryAllByTestId("node")).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/PatternCanvas.tsx
+++ b/frontend/src/components/PatternCanvas.tsx
@@ -1,0 +1,49 @@
+/**
+ * PatternCanvas — `PatternLoad` の状態に応じて描画内容を出し分ける表示専用コンポーネント。
+ *
+ * `PatternDisplay` にあった `renderContent`（loading / error / no-data / nodes の分岐）を
+ * そのまま兄弟のプレゼンテーショナルコンポーネントへ切り出したもの（規律3: 責務分離）。
+ * className・文言・`NodeRenderer` への map（`node.id` を key にする）は抽出元と一致させる。
+ * 状態を持たず props の `load` だけで描画が決まる純粋な表示層。
+ */
+
+import NodeRenderer from "./NodeRenderer";
+import type { PatternLoad } from "../lib/types";
+
+export interface PatternCanvasProps {
+  load: PatternLoad;
+}
+
+export default function PatternCanvas({ load }: PatternCanvasProps) {
+  if (load.status === "loading") {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-black text-white">
+        Loading pattern...
+      </div>
+    );
+  }
+
+  if (load.status === "error") {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-black text-white">
+        Error: {load.message}
+      </div>
+    );
+  }
+
+  if (!load.pattern.nodes) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-black text-white">
+        No pattern data
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {load.pattern.nodes.map((node) => (
+        <NodeRenderer key={node.id} node={node} />
+      ))}
+    </>
+  );
+}

--- a/frontend/src/components/PatternDisplay.tsx
+++ b/frontend/src/components/PatternDisplay.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import NodeRenderer from "./NodeRenderer";
+import { useRef } from "react";
+import PatternCanvas from "./PatternCanvas";
 import PatternMenu from "./PatternMenu";
 import CalibrationSettings from "./CalibrationSettings";
-import type { PatternLoad, XSGPattern } from "../lib/types";
+import { useFullscreen } from "../hooks/useFullscreen";
+import { usePatternLoader } from "../hooks/usePatternLoader";
 
 interface PatternDisplayProps {
   pattern: string;
@@ -12,129 +13,8 @@ interface PatternDisplayProps {
 
 export default function PatternDisplay({ pattern }: PatternDisplayProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Runtime load state (規律2): the loaded `XSGPattern` is an immutable
-  // definition; loading/error live alongside it in this `PatternLoad` value
-  // rather than overloading the definition type as a state container.
-  const [load, setLoad] = useState<PatternLoad>({ status: "loading" });
-
-  useEffect(() => {
-    // Request fullscreen on mount
-    const requestFullscreen = async () => {
-      if (containerRef.current && document.documentElement.requestFullscreen) {
-        try {
-          await document.documentElement.requestFullscreen();
-        } catch (err) {
-          console.warn("Fullscreen request failed:", err);
-        }
-      }
-    };
-
-    requestFullscreen();
-  }, []);
-
-  useEffect(() => {
-    const loadPatternFile = async () => {
-      setLoad({ status: "loading" });
-
-      try {
-        // Map common pattern names to pattern IDs
-        const patternMap: Record<string, string> = {
-          colorbar: "colorbar",
-          colorbars: "colorbar",
-          smpte: "colorbar",
-          ebu: "ebu-colorbar",
-          ebucolorbar: "ebu-colorbar",
-          arib: "arib-colorbar",
-          aribcolorbar: "arib-colorbar",
-          gradient: "gradient",
-          grayscale: "grayscale",
-          greyscale: "grayscale",
-          gray: "grayscale",
-          grey: "grayscale",
-          staircase: "staircase",
-          stairs: "staircase",
-          "vertical-gradient": "vertical-gradient",
-          "horizontal-gradient": "horizontal-gradient",
-          checker: "checker",
-          checkerboard: "checker",
-          crosshatch: "crosshatch",
-          grid: "crosshatch",
-          pluge: "pluge",
-          solid: "solid",
-          multiburst: "multiburst",
-          burst: "multiburst",
-          convergence: "convergence",
-          align: "convergence",
-          pixeldefect: "pixel-defect",
-          deadpixel: "pixel-defect",
-          dotdefect: "pixel-defect",
-        };
-
-        const patternId = patternMap[pattern.toLowerCase()] || "solid";
-
-        // Parse query parameters
-        const searchParams = new URLSearchParams(window.location.search);
-        const params: Record<string, string> = {};
-        searchParams.forEach((value, key) => {
-          if (key !== "pattern") {
-            // Exclude 'pattern' itself
-            params[key] = value;
-          }
-        });
-
-        // Use safeInvoke for Tauri/web compatibility
-        const { safeInvoke } = await import("../lib/tauriCompat");
-        const data = (await safeInvoke("get_pattern", {
-          patternId,
-          params,
-        })) as XSGPattern;
-
-        setLoad({ status: "ready", pattern: data });
-      } catch (err) {
-        console.error("Failed to load pattern:", err);
-        setLoad({
-          status: "error",
-          message: err instanceof Error ? err.message : "Failed to load pattern",
-        });
-      }
-    };
-
-    loadPatternFile();
-  }, [pattern]);
-
-  const renderContent = () => {
-    if (load.status === "loading") {
-      return (
-        <div className="w-full h-full flex items-center justify-center bg-black text-white">
-          Loading pattern...
-        </div>
-      );
-    }
-
-    if (load.status === "error") {
-      return (
-        <div className="w-full h-full flex items-center justify-center bg-black text-white">
-          Error: {load.message}
-        </div>
-      );
-    }
-
-    if (!load.pattern.nodes) {
-      return (
-        <div className="w-full h-full flex items-center justify-center bg-black text-white">
-          No pattern data
-        </div>
-      );
-    }
-
-    return (
-      <>
-        {load.pattern.nodes.map((node: any) => (
-          <NodeRenderer key={node.id} node={node} />
-        ))}
-      </>
-    );
-  };
+  useFullscreen(containerRef);
+  const load = usePatternLoader(pattern);
 
   return (
     <div
@@ -142,7 +22,7 @@ export default function PatternDisplay({ pattern }: PatternDisplayProps) {
       className="w-screen h-screen overflow-hidden relative"
       style={{ imageRendering: "pixelated" }}
     >
-      {renderContent()}
+      <PatternCanvas load={load} />
       <PatternMenu />
       <CalibrationSettings />
     </div>

--- a/frontend/src/hooks/useFullscreen.test.tsx
+++ b/frontend/src/hooks/useFullscreen.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * useFullscreen — マウント時フルスクリーン要求フックのテスト。
+ *
+ * Issue #14 で `PatternDisplay` から切り出した副作用フック。抽出が将来壊れない
+ * よう「いつ requestFullscreen を呼ぶか／reject を握りつぶすか」の契約を固定する。
+ * 守る挙動:
+ *   - `ref.current` が要素を指すとき documentElement.requestFullscreen を1回だけ呼ぶ
+ *   - `ref.current` が null のときは呼ばない（存在判定にだけ ref を使う）
+ *   - requestFullscreen が reject しても throw せず console.warn するだけ
+ *   - マウント中に多重発火しない（呼び出しは1回）
+ *
+ * jsdom には requestFullscreen が無いので、document.documentElement に mock を
+ * 差し込み、各テスト後に restore する（リークさせない）。
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useRef, type RefObject } from "react";
+import { useFullscreen } from "./useFullscreen";
+
+// ---------------------------------------------------------------------------
+// ヘルパ — requestFullscreen を mock し、テスト後に元へ戻す。
+// ---------------------------------------------------------------------------
+
+/**
+ * document.documentElement.requestFullscreen を差し替える。
+ * impl: Promise<void> を返すので mockResolvedValue(undefined) / mockRejectedValue。
+ * 返り値の restore() を afterEach で必ず呼ぶ。
+ */
+function mockRequestFullscreen(impl: () => Promise<void>): {
+  fn: ReturnType<typeof vi.fn>;
+  restore: () => void;
+} {
+  const el = document.documentElement as unknown as {
+    requestFullscreen?: () => Promise<void>;
+  };
+  const original = el.requestFullscreen;
+  const fn = vi.fn(impl);
+  el.requestFullscreen = fn;
+  return {
+    fn,
+    restore: () => {
+      el.requestFullscreen = original;
+    },
+  };
+}
+
+/** 後始末用に積んだ restore たちを afterEach でまとめて実行する。 */
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+  vi.restoreAllMocks();
+});
+
+/** 要素を指す ref を返す小フックでフックを駆動する（ref.current = 実 div）。 */
+function renderWithElementRef() {
+  return renderHook(() => {
+    const ref = useRef<HTMLDivElement | null>(null);
+    // 初回レンダー時点で current を実要素に固定（マウント effect で参照される）。
+    if (ref.current === null) {
+      ref.current = document.createElement("div");
+    }
+    useFullscreen(ref);
+    return ref;
+  });
+}
+
+/** current=null の ref でフックを駆動する。 */
+function renderWithNullRef() {
+  const nullRef: RefObject<HTMLElement | null> = { current: null };
+  return renderHook(() => {
+    useFullscreen(nullRef);
+  });
+}
+
+// ---------------------------------------------------------------------------
+describe("useFullscreen", () => {
+  it("ref.current が要素を指すとき requestFullscreen を1回呼ぶ", async () => {
+    // --- 仕様: マウント時 ref に要素があれば documentElement にフルスクリーン要求 ---
+    const { fn, restore } = mockRequestFullscreen(() =>
+      Promise.resolve(undefined)
+    );
+    cleanups.push(restore);
+
+    renderWithElementRef();
+
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+  });
+
+  it("ref.current が null のときは requestFullscreen を呼ばない", async () => {
+    // --- 仕様: ref は存在判定にだけ使う。要素が無ければ要求しない ---
+    const { fn, restore } = mockRequestFullscreen(() =>
+      Promise.resolve(undefined)
+    );
+    cleanups.push(restore);
+
+    renderWithNullRef();
+
+    // effect は同期的に走るので、待っても呼ばれていないことを確認する。
+    await Promise.resolve();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("requestFullscreen が reject しても throw せず console.warn する", async () => {
+    // --- 仕様: 失敗は握りつぶし console.warn のみ（呼び出し側に例外を伝播しない）---
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    cleanups.push(() => warnSpy.mockRestore());
+    const { fn, restore } = mockRequestFullscreen(() =>
+      Promise.reject(new Error("denied"))
+    );
+    cleanups.push(restore);
+
+    // renderHook 自体が throw しない（reject は内部で catch される）。
+    expect(() => renderWithElementRef()).not.toThrow();
+
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(warnSpy).toHaveBeenCalledTimes(1));
+    // 第1引数は抽出元と同じ警告メッセージ。
+    expect(warnSpy.mock.calls[0][0]).toBe("Fullscreen request failed:");
+  });
+
+  it("マウント中に多重発火しない（rerender しても増えない）", async () => {
+    // --- 仕様: effect の依存は [ref] のみ。同じ ref で再描画しても再要求しない ---
+    const { fn, restore } = mockRequestFullscreen(() =>
+      Promise.resolve(undefined)
+    );
+    cleanups.push(restore);
+
+    const { rerender } = renderWithElementRef();
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+
+    // 同一 ref のまま複数回再描画 → effect は再実行されない。
+    rerender();
+    rerender();
+    await Promise.resolve();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useFullscreen.ts
+++ b/frontend/src/hooks/useFullscreen.ts
@@ -1,0 +1,27 @@
+/**
+ * useFullscreen — マウント時に1度だけフルスクリーンを要求する副作用フック。
+ *
+ * `PatternDisplay` の「マウント時に `document.documentElement.requestFullscreen()`
+ * を試み、失敗は `console.warn` する」副作用をそのまま切り出したもの（規律3: 責務分離）。
+ * 渡された `ref` の要素が存在し、かつ `requestFullscreen` が使えるときだけ要求する。
+ * 挙動は抽出元と一致（要求は documentElement に対して行い、ref は存在判定にのみ使う）。
+ */
+
+import { useEffect, type RefObject } from "react";
+
+export function useFullscreen(ref: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    // Request fullscreen on mount
+    const requestFullscreen = async () => {
+      if (ref.current && document.documentElement.requestFullscreen) {
+        try {
+          await document.documentElement.requestFullscreen();
+        } catch (err) {
+          console.warn("Fullscreen request failed:", err);
+        }
+      }
+    };
+
+    requestFullscreen();
+  }, [ref]);
+}

--- a/frontend/src/hooks/usePatternLoader.test.tsx
+++ b/frontend/src/hooks/usePatternLoader.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * usePatternLoader — pattern 名から XSGPattern を読み込む runtime 状態フックのテスト。
+ *
+ * Issue #14 で `PatternDisplay` の読込 useEffect から切り出したフック。抽出が
+ * 将来壊れないよう、状態遷移と safeInvoke への引数組み立てを固定する。
+ * 守る挙動:
+ *   - 初期状態は loading
+ *   - 解決成功で ready になり pattern が safeInvoke の戻り値そのもの
+ *   - safeInvoke は ("get_pattern", { patternId: resolvePatternId(pattern),
+ *     params: parsePatternParams(location.search) }) で呼ばれる
+ *   - reject 時は error 状態（message 設定）＋ console.error
+ *   - pattern prop が変わると再読込される（loading→新 ready）
+ *
+ * 純粋ロジック（resolvePatternId / parsePatternParams）は patternId.test.ts が
+ * 固定済みなので、ここでは「フックがそれらを正しく呼び結線しているか」だけを見る。
+ *
+ * safeInvoke は `../lib/tauriCompat` から動的 import されるため vi.mock で差し替える。
+ * window.location.search はテストごとに設定し afterEach で元へ戻す。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { usePatternLoader } from "./usePatternLoader";
+import type { XSGPattern } from "../lib/types";
+
+// safeInvoke を mock 化（動的 import 先の module を丸ごと差し替える）。
+const safeInvokeMock = vi.fn();
+vi.mock("../lib/tauriCompat", () => ({
+  safeInvoke: (...args: unknown[]) => safeInvokeMock(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// window.location.search の制御（テスト後に restore）。
+// ---------------------------------------------------------------------------
+
+const originalSearch = window.location.search;
+
+/** location.search を上書きする（先頭 ? を含む形）。 */
+function setSearch(search: string): void {
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, search },
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  safeInvokeMock.mockReset();
+  setSearch("");
+});
+
+afterEach(() => {
+  setSearch(originalSearch);
+  vi.restoreAllMocks();
+});
+
+/** テスト用の最小 XSGPattern（nodes 有り）。 */
+function samplePattern(): XSGPattern {
+  return { canvas: { width: 100, height: 100 }, nodes: [] };
+}
+
+// ---------------------------------------------------------------------------
+describe("usePatternLoader", () => {
+  it("初期状態は loading", () => {
+    // --- 仕様: 読込開始前（同期初期値）は status:loading ---
+    // safeInvoke は永遠に解決しない Promise にして loading を観測する。
+    safeInvokeMock.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => usePatternLoader("solid"));
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("解決成功で ready になり pattern が safeInvoke の戻り値になる", async () => {
+    // --- 仕様: get_pattern の戻り値をそのまま { status:ready, pattern } に載せる ---
+    const data = samplePattern();
+    safeInvokeMock.mockResolvedValue(data);
+
+    const { result } = renderHook(() => usePatternLoader("colorbar"));
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status !== "ready") throw new Error("not ready");
+    // 戻り値の同一参照がそのまま入る。
+    expect(result.current.pattern).toBe(data);
+  });
+
+  it('safeInvoke を ("get_pattern", { patternId, params }) で呼ぶ', async () => {
+    // --- 仕様: patternId=resolvePatternId(pattern)、params=parsePatternParams(search) ---
+    // alias "colorbars" → "colorbar"。search は pattern 自身を除外し残りを渡す。
+    setSearch("?pattern=colorbars&hue=red&level=50");
+    safeInvokeMock.mockResolvedValue(samplePattern());
+
+    const { result } = renderHook(() => usePatternLoader("colorbars"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(safeInvokeMock).toHaveBeenCalledTimes(1);
+    expect(safeInvokeMock).toHaveBeenCalledWith("get_pattern", {
+      patternId: "colorbar", // resolvePatternId("colorbars")
+      params: { hue: "red", level: "50" }, // pattern キーは除外
+    });
+  });
+
+  it("未知の pattern 名は patternId が solid にフォールバックして呼ばれる", async () => {
+    // --- 仕様: resolvePatternId は未知名を "solid" に落とす。その結線を確認 ---
+    safeInvokeMock.mockResolvedValue(samplePattern());
+
+    const { result } = renderHook(() => usePatternLoader("does-not-exist"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(safeInvokeMock).toHaveBeenCalledWith("get_pattern", {
+      patternId: "solid",
+      params: {},
+    });
+  });
+
+  it("reject 時は error 状態（message 設定）＋ console.error を呼ぶ", async () => {
+    // --- 仕様: 失敗は status:error に落とし、Error.message を message にする ---
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    safeInvokeMock.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => usePatternLoader("solid"));
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status !== "error") throw new Error("not error");
+    expect(result.current.message).toBe("boom");
+    // 抽出元と同じログ前置き。
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to load pattern:",
+      expect.any(Error)
+    );
+  });
+
+  it("Error でない reject はフォールバック文言になる", async () => {
+    // --- 仕様: err が Error でないとき message は "Failed to load pattern" ---
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    safeInvokeMock.mockRejectedValue("just a string");
+
+    const { result } = renderHook(() => usePatternLoader("solid"));
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status !== "error") throw new Error("not error");
+    expect(result.current.message).toBe("Failed to load pattern");
+  });
+
+  it("pattern prop が変わると再読込される（loading→新 ready）", async () => {
+    // --- 仕様: effect 依存は [pattern]。pattern 変更で loading に戻り再 invoke する ---
+    const first = samplePattern();
+    const second: XSGPattern = { ...samplePattern(), extends: "x" };
+    safeInvokeMock.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+
+    const { result, rerender } = renderHook(
+      ({ p }: { p: string }) => usePatternLoader(p),
+      { initialProps: { p: "colorbar" } }
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status !== "ready") throw new Error("not ready (1)");
+    expect(result.current.pattern).toBe(first);
+
+    // pattern を切り替える → 再度 safeInvoke が呼ばれ ready が更新される。
+    rerender({ p: "grayscale" });
+    await waitFor(() => {
+      expect(result.current.status).toBe("ready");
+      if (result.current.status !== "ready") throw new Error("not ready (2)");
+      expect(result.current.pattern).toBe(second);
+    });
+
+    expect(safeInvokeMock).toHaveBeenCalledTimes(2);
+    // 2回目の patternId は grayscale に解決されている。
+    expect(safeInvokeMock.mock.calls[1][0]).toBe("get_pattern");
+    expect(
+      (safeInvokeMock.mock.calls[1][1] as { patternId: string }).patternId
+    ).toBe("grayscale");
+  });
+});

--- a/frontend/src/hooks/usePatternLoader.ts
+++ b/frontend/src/hooks/usePatternLoader.ts
@@ -1,0 +1,56 @@
+/**
+ * usePatternLoader — `pattern` 名から `XSGPattern` を読み込む runtime 状態フック。
+ *
+ * `PatternDisplay` にあった読込 useEffect をそのまま切り出したもの（規律3: 責務分離）。
+ * `pattern` が変わるたびに `loading` へ戻し、`resolvePatternId` / `parsePatternParams` で
+ * リクエスト引数を組み立て、`safeInvoke("get_pattern", ...)` で取得して `ready`/`error` に
+ * 落とす。`console.error` のエラーログも抽出元のまま。
+ *
+ * 規律2: 返す `PatternLoad` は「不変の定義 `XSGPattern`」と「読込の実行時状態
+ * (loading/error)」を型で分けた値であり、`XSGPattern` を状態の入れ物に流用しない。
+ */
+
+import { useEffect, useState } from "react";
+import { parsePatternParams, resolvePatternId } from "../lib/patternId";
+import type { PatternLoad, XSGPattern } from "../lib/types";
+
+export function usePatternLoader(pattern: string): PatternLoad {
+  // Runtime load state (規律2): the loaded `XSGPattern` is an immutable
+  // definition; loading/error live alongside it in this `PatternLoad` value
+  // rather than overloading the definition type as a state container.
+  const [load, setLoad] = useState<PatternLoad>({ status: "loading" });
+
+  useEffect(() => {
+    const loadPatternFile = async () => {
+      setLoad({ status: "loading" });
+
+      try {
+        // Map common pattern names to pattern IDs
+        const patternId = resolvePatternId(pattern);
+
+        // Parse query parameters (excluding 'pattern' itself)
+        const params = parsePatternParams(window.location.search);
+
+        // Use safeInvoke for Tauri/web compatibility
+        const { safeInvoke } = await import("../lib/tauriCompat");
+        const data = (await safeInvoke("get_pattern", {
+          patternId,
+          params,
+        })) as XSGPattern;
+
+        setLoad({ status: "ready", pattern: data });
+      } catch (err) {
+        console.error("Failed to load pattern:", err);
+        setLoad({
+          status: "error",
+          message:
+            err instanceof Error ? err.message : "Failed to load pattern",
+        });
+      }
+    };
+
+    loadPatternFile();
+  }, [pattern]);
+
+  return load;
+}

--- a/frontend/src/lib/patternId.test.ts
+++ b/frontend/src/lib/patternId.test.ts
@@ -1,0 +1,110 @@
+/**
+ * patternId — characterization golden（#14）。
+ *
+ * `resolvePatternId` / `parsePatternParams` を `PatternDisplay.tsx` のインライン実装から
+ * 純粋関数へ抽出するにあたり、抽出前の挙動をリテラルで固定する回帰スイート。
+ * ここが緑であることが「挙動を1文字も変えていない」担保になる（characterization-first）。
+ *
+ * 方針:
+ *   - `resolvePatternId` は全別名（colorbar 系/ebu/arib/gradient/grayscale 系/staircase 系/
+ *     checker 系/crosshatch 系/pluge/solid/multiburst 系/convergence 系/pixel-defect 系）と
+ *     未知名→solid、大文字混在（`COLORBAR` 等）を網羅する。
+ *   - `parsePatternParams` は `pattern` 除外・複数パラメータ・空・混在クエリを固定する。
+ */
+
+import { describe, expect, it } from "vitest";
+import { parsePatternParams, resolvePatternId } from "./patternId";
+
+describe("resolvePatternId — alias → id（characterization）", () => {
+  // 抽出元 patternMap の全エントリ（名前 → 期待 id）を網羅する。
+  const aliasTable: Array<[string, string]> = [
+    ["colorbar", "colorbar"],
+    ["colorbars", "colorbar"],
+    ["smpte", "colorbar"],
+    ["ebu", "ebu-colorbar"],
+    ["ebucolorbar", "ebu-colorbar"],
+    ["arib", "arib-colorbar"],
+    ["aribcolorbar", "arib-colorbar"],
+    ["gradient", "gradient"],
+    ["grayscale", "grayscale"],
+    ["greyscale", "grayscale"],
+    ["gray", "grayscale"],
+    ["grey", "grayscale"],
+    ["staircase", "staircase"],
+    ["stairs", "staircase"],
+    ["vertical-gradient", "vertical-gradient"],
+    ["horizontal-gradient", "horizontal-gradient"],
+    ["checker", "checker"],
+    ["checkerboard", "checker"],
+    ["crosshatch", "crosshatch"],
+    ["grid", "crosshatch"],
+    ["pluge", "pluge"],
+    ["solid", "solid"],
+    ["multiburst", "multiburst"],
+    ["burst", "multiburst"],
+    ["convergence", "convergence"],
+    ["align", "convergence"],
+    ["pixeldefect", "pixel-defect"],
+    ["deadpixel", "pixel-defect"],
+    ["dotdefect", "pixel-defect"],
+  ];
+
+  it.each(aliasTable)("%s → %s", (name, expected) => {
+    expect(resolvePatternId(name)).toBe(expected);
+  });
+
+  it("未知名は solid に落ちる", () => {
+    expect(resolvePatternId("nope")).toBe("solid");
+    expect(resolvePatternId("")).toBe("solid");
+    expect(resolvePatternId("colorbarz")).toBe("solid");
+    expect(resolvePatternId("xyz123")).toBe("solid");
+  });
+
+  it("大文字・混在ケースは toLowerCase 経由で解決される", () => {
+    expect(resolvePatternId("COLORBAR")).toBe("colorbar");
+    expect(resolvePatternId("ColorBar")).toBe("colorbar");
+    expect(resolvePatternId("SMPTE")).toBe("colorbar");
+    expect(resolvePatternId("EBU")).toBe("ebu-colorbar");
+    expect(resolvePatternId("GrayScale")).toBe("grayscale");
+    expect(resolvePatternId("Vertical-Gradient")).toBe("vertical-gradient");
+    expect(resolvePatternId("DeadPixel")).toBe("pixel-defect");
+  });
+});
+
+describe("parsePatternParams — pattern 除外（characterization）", () => {
+  it("pattern キーを除外し他を残す", () => {
+    expect(parsePatternParams("?pattern=x&foo=1&bar=2")).toEqual({
+      foo: "1",
+      bar: "2",
+    });
+  });
+
+  it("pattern のみのクエリは空オブジェクト", () => {
+    expect(parsePatternParams("?pattern=colorbar")).toEqual({});
+  });
+
+  it("空クエリは空オブジェクト", () => {
+    expect(parsePatternParams("")).toEqual({});
+    expect(parsePatternParams("?")).toEqual({});
+  });
+
+  it("pattern を含まないクエリは全パラメータを残す", () => {
+    expect(parsePatternParams("?steps=21&startColor=%23FF0000")).toEqual({
+      steps: "21",
+      startColor: "#FF0000",
+    });
+  });
+
+  it("先頭 ? の有無に依らない（URLSearchParams は両方受ける）", () => {
+    expect(parsePatternParams("foo=1&bar=2")).toEqual({ foo: "1", bar: "2" });
+  });
+
+  it("同名キーは最後の値が勝つ（URLSearchParams.forEach の挙動）", () => {
+    // forEach は各値を順に渡し、同じキーは後勝ちで上書きされる。
+    expect(parsePatternParams("?foo=1&foo=2&foo=3")).toEqual({ foo: "3" });
+  });
+
+  it("値なしパラメータは空文字列になる", () => {
+    expect(parsePatternParams("?foo&bar=2")).toEqual({ foo: "", bar: "2" });
+  });
+});

--- a/frontend/src/lib/patternId.ts
+++ b/frontend/src/lib/patternId.ts
@@ -1,0 +1,75 @@
+/**
+ * patternId — パターン名解決とクエリパラメータ解析の純粋ロジック。
+ *
+ * もとは `PatternDisplay.tsx` の読込 useEffect 内にインラインで埋まっていた2つの
+ * 純粋関数を、テスト可能な単位として切り出したもの（規律3: 計算ロジックの隔離）。
+ * 別名テーブル・`toLowerCase()`・fallback `"solid"`・`pattern` キー除外の挙動は
+ * 抽出元と1文字も変えていない（characterization テストが固定する）。
+ */
+
+/**
+ * よく使われるパターン名（別名含む）→ パターン ID の対応表。
+ *
+ * 抽出元（`PatternDisplay.tsx`）のインライン定義をそのまま移したもの。
+ * 並び・別名・値はいずれも変更しない。
+ */
+const PATTERN_MAP: Record<string, string> = {
+  colorbar: "colorbar",
+  colorbars: "colorbar",
+  smpte: "colorbar",
+  ebu: "ebu-colorbar",
+  ebucolorbar: "ebu-colorbar",
+  arib: "arib-colorbar",
+  aribcolorbar: "arib-colorbar",
+  gradient: "gradient",
+  grayscale: "grayscale",
+  greyscale: "grayscale",
+  gray: "grayscale",
+  grey: "grayscale",
+  staircase: "staircase",
+  stairs: "staircase",
+  "vertical-gradient": "vertical-gradient",
+  "horizontal-gradient": "horizontal-gradient",
+  checker: "checker",
+  checkerboard: "checker",
+  crosshatch: "crosshatch",
+  grid: "crosshatch",
+  pluge: "pluge",
+  solid: "solid",
+  multiburst: "multiburst",
+  burst: "multiburst",
+  convergence: "convergence",
+  align: "convergence",
+  pixeldefect: "pixel-defect",
+  deadpixel: "pixel-defect",
+  dotdefect: "pixel-defect",
+};
+
+/**
+ * パターン名（別名可・大文字小文字を問わない）をパターン ID に解決する。
+ *
+ * 小文字化したうえで {@link PATTERN_MAP} を引き、未知名は `"solid"` に落とす。
+ * 抽出元: `patternMap[pattern.toLowerCase()] || "solid"`。
+ */
+export function resolvePatternId(name: string): string {
+  return PATTERN_MAP[name.toLowerCase()] || "solid";
+}
+
+/**
+ * クエリ文字列から `pattern` キーを除いた全パラメータを `Record<string,string>` にする。
+ *
+ * 抽出元は `new URLSearchParams(window.location.search)` を回して `pattern` 以外を
+ * 集める処理。ここでは検索文字列を引数で受け取り純粋関数化しているが、走査・除外規則・
+ * 同名キーの最終勝ち（`URLSearchParams.forEach` の挙動）はそのまま維持する。
+ */
+export function parsePatternParams(search: string): Record<string, string> {
+  const searchParams = new URLSearchParams(search);
+  const params: Record<string, string> = {};
+  searchParams.forEach((value, key) => {
+    if (key !== "pattern") {
+      // Exclude 'pattern' itself
+      params[key] = value;
+    }
+  });
+  return params;
+}


### PR DESCRIPTION
## 関連 Issue
closes #14

## 概要
god 化していた2ファイルを単一責務に分解する**挙動保存リファクタ**（機能追加・バグ修正・最適化なし、移動/抽出のみ）。

## Rust: `lib.rs`(212→111行)
- 新規 `window_manager.rs`(151行) に **window 生成・`.setup()` のモニタ列挙→display選択→ウィンドウ生成ループ・single-instance のパターン切替コールバック** を移管。
- 重複していた dev/prod URL 生成（`debug_assertions` 分岐が2箇所）を `pattern_url()` 単一ヘルパに集約（文字列整形は完全一致）。
- `lib.rs` は **Tauri command 定義 + `run()` のプラグイン/ハンドラ配線** に限定。display 選択ロジックは従来どおり `displays.rs`。
- 検証: 既存 `tests/golden_e2e.rs` 11件緑・`cargo build` 緑・変更ファイル(lib.rs/window_manager.rs)は clippy クリーン。

## TS: `PatternDisplay.tsx`(150→30行)
- **純粋ロジックを抽出**（characterization-first）: `lib/patternId.ts` に `resolvePatternId(name)`（patternMap の別名解決・fallback `solid`）と `parsePatternParams(search)`（`pattern` キー除外）。先に `patternId.test.ts`(38件) で現状挙動を golden 固定してから差し替え。
- **フック抽出**: `useFullscreen(ref)`（マウント時フルスクリーン要求）・`usePatternLoader(pattern): PatternLoad`（読込 useEffect・状態遷移）。
- **描画分岐を兄弟コンポーネント `PatternCanvas.tsx` に分離**（loading/error/no-data/nodes）。
- `PatternDisplay` は合成のみに。規律2（不変定義 `XSGPattern` と実行時状態 `PatternLoad` の型分離）を維持。
- 抽出物のテスト追加: `useFullscreen`(4)・`usePatternLoader`(7)・`PatternCanvas`(5)。

## テスト
- `npm test`: **168 passed**（既存152 + patternId characterization 38 + 抽出物 16）。
- `cargo test`: 11 passed。
- 挙動保存の担保: 純粋ロジックは characterization 先行で golden 一致、Rust は行単位の移動 + golden_e2e 緑、UI 分岐は文言/className/deps を不変。

## docs / follow-up
- 本リファクタのコードに一致する正確な docs は無し（更新不要）。`preset-system.md` の移行節・`path-resolution.md` は旧 Python 時代のドリフトで、本変更とは独立 → #27 で追跡。
- `calibration/` に新しめのローカル toolchain でのみ点く clippy 3件（本 PR 無関係の pre-existing）を発見 → 別途 follow-up 予定。