### PR TITLE
fix: web モードで preset/background ノードを展開し黒落ちを解消 (#23)

### DIFF
--- a/frontend/src/components/SlideshowView.tsx
+++ b/frontend/src/components/SlideshowView.tsx
@@ -179,11 +179,9 @@ function PatternSlide({ path }: { path: string }) {
     const run = async () => {
       setLoad({ status: "loading" });
       try {
-        const { safeInvoke } = await import("../lib/tauriCompat");
-        const data = await safeInvoke<XSGPattern>("get_pattern", {
-          patternId: patternIdFromPath(path),
-          params: {},
-        });
+        // get_pattern 取得 + preset/background 展開（Issue #23）。
+        const { loadResolvedPattern } = await import("../lib/tauriCompat");
+        const data = await loadResolvedPattern(patternIdFromPath(path), {});
         if (!cancelled) setLoad({ status: "ready", pattern: data });
       } catch (err) {
         if (!cancelled) {

--- a/frontend/src/hooks/usePatternLoader.test.tsx
+++ b/frontend/src/hooks/usePatternLoader.test.tsx
@@ -123,15 +123,17 @@ describe("usePatternLoader", () => {
     });
   });
 
-  it("未知の pattern 名は patternId が solid にフォールバックして呼ばれる", async () => {
-    // --- 仕様: resolvePatternId は未知名を "solid" に落とす。その結線を確認 ---
+  it("未知の pattern 名はファイル名としてそのまま patternId に渡る（#23: solid 黙殺廃止）", async () => {
+    // --- 仕様: resolvePatternId は未知名を "solid" に黙殺せず、名前をそのまま ---
+    // pattern id として返す。エイリアス未登録の colorbar-simple 等へ到達できる。
+    // その結線（未知名 → loader にそのまま渡る）を確認する。
     safeInvokeMock.mockResolvedValue(samplePattern());
 
     const { result } = renderHook(() => usePatternLoader("does-not-exist"));
     await waitFor(() => expect(result.current.status).toBe("ready"));
 
     expect(safeInvokeMock).toHaveBeenCalledWith("get_pattern", {
-      patternId: "solid",
+      patternId: "does-not-exist",
       params: {},
     });
   });

--- a/frontend/src/hooks/usePatternLoader.test.tsx
+++ b/frontend/src/hooks/usePatternLoader.test.tsx
@@ -14,19 +14,44 @@
  * 純粋ロジック（resolvePatternId / parsePatternParams）は patternId.test.ts が
  * 固定済みなので、ここでは「フックがそれらを正しく呼び結線しているか」だけを見る。
  *
- * safeInvoke は `../lib/tauriCompat` から動的 import されるため vi.mock で差し替える。
+ * フックは `../lib/tauriCompat` から `loadResolvedPattern` を動的 import する
+ * （Issue #23 で `safeInvoke("get_pattern", ...)` 直呼びから差し替え）。preset 展開
+ * の有無を含めた経路を再現するため、mock では本物の `loadResolvedPattern` を
+ * mock 化した `safeInvoke` に結線して使う。これにより従来どおり safeInvoke の
+ * 引数（`("get_pattern", { patternId, params })`）を検証でき、nodes が空（=preset
+ * を含まない）の戻りでは expandPresets が no-op になり戻り値の同一参照も保たれる。
  * window.location.search はテストごとに設定し afterEach で元へ戻す。
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { usePatternLoader } from "./usePatternLoader";
+import { expandPresets } from "../lib/presetExpander";
 import type { XSGPattern } from "../lib/types";
 
 // safeInvoke を mock 化（動的 import 先の module を丸ごと差し替える）。
+// フックは loadResolvedPattern を import するので、それも mock で再現する:
+// 本番同様 safeInvoke("get_pattern", ...) の戻りを expandPresets に通す結線にし、
+// safeInvoke の呼び出し引数を従来どおり検証できるようにする。nodes が空（preset を
+// 含まない）戻りでは expandPresets は no-op になり戻り値の同一参照も保たれる。
 const safeInvokeMock = vi.fn();
 vi.mock("../lib/tauriCompat", () => ({
   safeInvoke: (...args: unknown[]) => safeInvokeMock(...args),
+  loadResolvedPattern: async (
+    patternId: string,
+    params: Record<string, string>
+  ): Promise<XSGPattern> => {
+    const base = (await safeInvokeMock("get_pattern", {
+      patternId,
+      params,
+    })) as XSGPattern | undefined;
+    // 本番の safeInvoke は常に XSGPattern を返すが、テストでは mockReset 後の
+    // 取りこぼし（undefined）でクラッシュしないよう保険を入れる。
+    if (!base) return { nodes: [] };
+    return expandPresets(base, (id, p) =>
+      safeInvokeMock("get_pattern", { patternId: id, params: p })
+    );
+  },
 }));
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/hooks/usePatternLoader.ts
+++ b/frontend/src/hooks/usePatternLoader.ts
@@ -12,7 +12,7 @@
 
 import { useEffect, useState } from "react";
 import { parsePatternParams, resolvePatternId } from "../lib/patternId";
-import type { PatternLoad, XSGPattern } from "../lib/types";
+import type { PatternLoad } from "../lib/types";
 
 export function usePatternLoader(pattern: string): PatternLoad {
   // Runtime load state (規律2): the loaded `XSGPattern` is an immutable
@@ -31,12 +31,10 @@ export function usePatternLoader(pattern: string): PatternLoad {
         // Parse query parameters (excluding 'pattern' itself)
         const params = parsePatternParams(window.location.search);
 
-        // Use safeInvoke for Tauri/web compatibility
-        const { safeInvoke } = await import("../lib/tauriCompat");
-        const data = (await safeInvoke("get_pattern", {
-          patternId,
-          params,
-        })) as XSGPattern;
+        // get_pattern 取得 + preset/background 展開（Issue #23）。
+        // loadResolvedPattern が Tauri/web 双方で参照先 nodes まで解決する。
+        const { loadResolvedPattern } = await import("../lib/tauriCompat");
+        const data = await loadResolvedPattern(patternId, params);
 
         setLoad({ status: "ready", pattern: data });
       } catch (err) {

--- a/frontend/src/lib/patternId.test.ts
+++ b/frontend/src/lib/patternId.test.ts
@@ -8,10 +8,12 @@
  * 方針:
  *   - `resolvePatternId` は全別名（colorbar 系/ebu/arib/gradient/grayscale 系/staircase 系/
  *     checker 系/crosshatch 系/pluge/solid/multiburst 系/convergence 系/pixel-defect 系）と
- *     未知名→その名前自身（ファイル名扱い）、大文字混在（`COLORBAR` 等）を網羅する。
- *   - #23 で未知名フォールバックを `"solid"` 黙殺 → 名前パススルーに変更したため、
- *     未知名ケースの期待値を「その名前自身（lowercased）」に更新済み（意図的な
- *     characterization 更新）。空白のみは安全な既定として `"solid"` を温存。
+ *     安全な未知名→その名前自身（ファイル名扱い）、大文字混在（`COLORBAR` 等）を網羅する。
+ *   - #23 で未知名フォールバックを `"solid"` 黙殺 → 名前パススルーに変更したが、
+ *     パストラバーサル遮断のため passthrough は **安全な id（`[a-z0-9-]`、先頭英数字）**
+ *     に限定する。安全な未知名（`colorbar-simple` 等）のみその名前自身（lowercased）に
+ *     解決し、不正文字を含む名前（`../../etc/passwd`・`foo/bar`・`a.yaml` 等）と空白のみは
+ *     安全な既定 `"solid"` に倒す（意図的な characterization 更新）。
  *   - `parsePatternParams` は `pattern` 除外・複数パラメータ・空・混在クエリを固定する（不変）。
  */
 
@@ -56,11 +58,11 @@ describe("resolvePatternId — alias → id（characterization）", () => {
     expect(resolvePatternId(name)).toBe(expected);
   });
 
-  // #23: 未知名は「ファイル名」として扱い、そのまま pattern id に解決する
+  // #23: 安全な未知名は「ファイル名」として扱い、そのまま pattern id に解決する
   // （旧挙動の `"solid"` 黙殺を廃止）。エイリアス未登録の colorbar-simple 等の
   // パターンファイルへ `?pattern=` で到達できるようにするための意図的な characterization 更新。
   // 実在しない名前は loader が 404 → error 状態にする（黒画面でなく明示エラー）。
-  it("未知名はファイル名としてそのまま扱う（solid 黙殺を廃止）", () => {
+  it("安全な未知名はファイル名としてそのまま扱う（solid 黙殺を廃止）", () => {
     expect(resolvePatternId("colorbar-simple")).toBe("colorbar-simple");
     expect(resolvePatternId("multi-layer-example")).toBe("multi-layer-example");
     expect(resolvePatternId("animation-example")).toBe("animation-example");
@@ -70,10 +72,27 @@ describe("resolvePatternId — alias → id（characterization）", () => {
     expect(resolvePatternId("xyz123")).toBe("xyz123");
   });
 
-  it("大文字混在の未知名も lowercased passthrough（ファイル名扱い）", () => {
+  it("大文字混在の安全な未知名も lowercased passthrough（ファイル名扱い）", () => {
     expect(resolvePatternId("Colorbar-Simple")).toBe("colorbar-simple");
     expect(resolvePatternId("Multi-Layer-Example")).toBe("multi-layer-example");
     expect(resolvePatternId("UNKNOWN-XYZ")).toBe("unknown-xyz");
+  });
+
+  // #23 security: passthrough は「安全な id（[a-z0-9-]・先頭英数字）」に限定する。
+  // パストラバーサル（`../../etc/passwd`・`foo/bar`）・拡張子注入（`a.yaml`・`a.b`）・
+  // 不正文字（空白・記号）を含む名前は passthrough せず安全な既定 `"solid"` に倒す。
+  // これがないと resolve 結果が Rust の patterns_dir.join(path) に渡り、patterns
+  // ディレクトリ外の任意 .yaml を読まれる（pattern_expander.load_pattern_file）。
+  it("パストラバーサル/不正文字は solid に倒す（passthrough 遮断）", () => {
+    expect(resolvePatternId("../../etc/passwd")).toBe("solid");
+    expect(resolvePatternId("foo/bar")).toBe("solid");
+    expect(resolvePatternId("a.yaml")).toBe("solid");
+    expect(resolvePatternId("a.b")).toBe("solid"); // ドットも除外＝拡張子注入防止
+    expect(resolvePatternId("..")).toBe("solid");
+    expect(resolvePatternId("foo bar")).toBe("solid"); // 内部空白
+    expect(resolvePatternId("foo\\bar")).toBe("solid"); // バックスラッシュ
+    expect(resolvePatternId("-leading-hyphen")).toBe("solid"); // 先頭ハイフンは不可
+    expect(resolvePatternId("foo_bar")).toBe("solid"); // アンダースコアは不可
   });
 
   // 空白のみ（空文字含む）は安全な既定として従来どおり solid を返す（防御ガード）。

--- a/frontend/src/lib/patternId.test.ts
+++ b/frontend/src/lib/patternId.test.ts
@@ -8,8 +8,11 @@
  * 方針:
  *   - `resolvePatternId` は全別名（colorbar 系/ebu/arib/gradient/grayscale 系/staircase 系/
  *     checker 系/crosshatch 系/pluge/solid/multiburst 系/convergence 系/pixel-defect 系）と
- *     未知名→solid、大文字混在（`COLORBAR` 等）を網羅する。
- *   - `parsePatternParams` は `pattern` 除外・複数パラメータ・空・混在クエリを固定する。
+ *     未知名→その名前自身（ファイル名扱い）、大文字混在（`COLORBAR` 等）を網羅する。
+ *   - #23 で未知名フォールバックを `"solid"` 黙殺 → 名前パススルーに変更したため、
+ *     未知名ケースの期待値を「その名前自身（lowercased）」に更新済み（意図的な
+ *     characterization 更新）。空白のみは安全な既定として `"solid"` を温存。
+ *   - `parsePatternParams` は `pattern` 除外・複数パラメータ・空・混在クエリを固定する（不変）。
  */
 
 import { describe, expect, it } from "vitest";
@@ -53,11 +56,31 @@ describe("resolvePatternId — alias → id（characterization）", () => {
     expect(resolvePatternId(name)).toBe(expected);
   });
 
-  it("未知名は solid に落ちる", () => {
-    expect(resolvePatternId("nope")).toBe("solid");
+  // #23: 未知名は「ファイル名」として扱い、そのまま pattern id に解決する
+  // （旧挙動の `"solid"` 黙殺を廃止）。エイリアス未登録の colorbar-simple 等の
+  // パターンファイルへ `?pattern=` で到達できるようにするための意図的な characterization 更新。
+  // 実在しない名前は loader が 404 → error 状態にする（黒画面でなく明示エラー）。
+  it("未知名はファイル名としてそのまま扱う（solid 黙殺を廃止）", () => {
+    expect(resolvePatternId("colorbar-simple")).toBe("colorbar-simple");
+    expect(resolvePatternId("multi-layer-example")).toBe("multi-layer-example");
+    expect(resolvePatternId("animation-example")).toBe("animation-example");
+    expect(resolvePatternId("unknown-xyz")).toBe("unknown-xyz");
+    expect(resolvePatternId("nope")).toBe("nope");
+    expect(resolvePatternId("colorbarz")).toBe("colorbarz");
+    expect(resolvePatternId("xyz123")).toBe("xyz123");
+  });
+
+  it("大文字混在の未知名も lowercased passthrough（ファイル名扱い）", () => {
+    expect(resolvePatternId("Colorbar-Simple")).toBe("colorbar-simple");
+    expect(resolvePatternId("Multi-Layer-Example")).toBe("multi-layer-example");
+    expect(resolvePatternId("UNKNOWN-XYZ")).toBe("unknown-xyz");
+  });
+
+  // 空白のみ（空文字含む）は安全な既定として従来どおり solid を返す（防御ガード）。
+  // App.tsx がデフォルト "colorbar" を保証するため実運用では来ない。
+  it("空文字・空白のみは安全な既定として solid を返す", () => {
     expect(resolvePatternId("")).toBe("solid");
-    expect(resolvePatternId("colorbarz")).toBe("solid");
-    expect(resolvePatternId("xyz123")).toBe("solid");
+    expect(resolvePatternId("   ")).toBe("solid");
   });
 
   it("大文字・混在ケースは toLowerCase 経由で解決される", () => {

--- a/frontend/src/lib/patternId.ts
+++ b/frontend/src/lib/patternId.ts
@@ -3,8 +3,10 @@
  *
  * もとは `PatternDisplay.tsx` の読込 useEffect 内にインラインで埋まっていた2つの
  * 純粋関数を、テスト可能な単位として切り出したもの（規律3: 計算ロジックの隔離）。
- * 別名テーブル・`toLowerCase()`・fallback `"solid"`・`pattern` キー除外の挙動は
- * 抽出元と1文字も変えていない（characterization テストが固定する）。
+ * 別名テーブル・`toLowerCase()`・`pattern` キー除外の挙動は抽出元と同じだが、
+ * `resolvePatternId` の未知名フォールバックは `"solid"` 黙殺を廃止し、名前を
+ * pattern id としてそのまま返すよう変更した（#23: エイリアス未登録のパターンファイル
+ * が到達不能になるバグの修正）。詳細は当該関数の JSDoc を参照。
  */
 
 /**
@@ -48,11 +50,22 @@ const PATTERN_MAP: Record<string, string> = {
 /**
  * パターン名（別名可・大文字小文字を問わない）をパターン ID に解決する。
  *
- * 小文字化したうえで {@link PATTERN_MAP} を引き、未知名は `"solid"` に落とす。
- * 抽出元: `patternMap[pattern.toLowerCase()] || "solid"`。
+ * 小文字化したうえで {@link PATTERN_MAP} を引き、既知のニックネームは canonical id へ
+ * 解決する。未知名は `"solid"` に黙殺せず、小文字化した名前を pattern id として
+ * そのまま扱う（ファイル名直指定を許可）。`colorbar-simple` のように
+ * {@link PATTERN_MAP} 未登録でも `/patterns/<name>.yaml`（web）/ root `patterns/`（Tauri）
+ * から loader がロードできる。実在しない名前は loader が 404 → `error` 状態にする
+ * （旧挙動の「黙って solid を出す」黒画面より、明示エラーの方が良 UX）。
+ *
+ * 空白のみ（または空文字）は安全な既定として従来どおり `"solid"` を返す。
+ * App.tsx がデフォルト `"colorbar"` を保証するため空文字は実運用で来ないが、防御的に温存する。
  */
 export function resolvePatternId(name: string): string {
-  return PATTERN_MAP[name.toLowerCase()] || "solid";
+  const normalized = name.trim().toLowerCase();
+  if (normalized === "") {
+    return "solid";
+  }
+  return PATTERN_MAP[normalized] ?? normalized;
 }
 
 /**

--- a/frontend/src/lib/patternId.ts
+++ b/frontend/src/lib/patternId.ts
@@ -4,10 +4,19 @@
  * もとは `PatternDisplay.tsx` の読込 useEffect 内にインラインで埋まっていた2つの
  * 純粋関数を、テスト可能な単位として切り出したもの（規律3: 計算ロジックの隔離）。
  * 別名テーブル・`toLowerCase()`・`pattern` キー除外の挙動は抽出元と同じだが、
- * `resolvePatternId` の未知名フォールバックは `"solid"` 黙殺を廃止し、名前を
- * pattern id としてそのまま返すよう変更した（#23: エイリアス未登録のパターンファイル
- * が到達不能になるバグの修正）。詳細は当該関数の JSDoc を参照。
+ * `resolvePatternId` の未知名フォールバックは `"solid"` 黙殺を廃止し、**安全な id**
+ * と確認できた名前のみ pattern id として返すよう変更した（#23: エイリアス未登録の
+ * パターンファイルが到達不能になるバグの修正＋パストラバーサル遮断）。詳細は当該
+ * 関数の JSDoc を参照。
  */
+
+/**
+ * 安全な pattern id（＝そのまま `.yaml` ファイル名にできる文字）の集合。
+ *
+ * 先頭は英数字、以降は英数字とハイフンのみ。`/`・`\`・`.`・`..`・空白・その他記号を
+ * 含む名前は弾く（パストラバーサル・拡張子注入・予期せぬパス注入の遮断）。
+ */
+const SAFE_PATTERN_ID = /^[a-z0-9][a-z0-9-]*$/;
 
 /**
  * よく使われるパターン名（別名含む）→ パターン ID の対応表。
@@ -50,14 +59,23 @@ const PATTERN_MAP: Record<string, string> = {
 /**
  * パターン名（別名可・大文字小文字を問わない）をパターン ID に解決する。
  *
- * 小文字化したうえで {@link PATTERN_MAP} を引き、既知のニックネームは canonical id へ
- * 解決する。未知名は `"solid"` に黙殺せず、小文字化した名前を pattern id として
- * そのまま扱う（ファイル名直指定を許可）。`colorbar-simple` のように
- * {@link PATTERN_MAP} 未登録でも `/patterns/<name>.yaml`（web）/ root `patterns/`（Tauri）
- * から loader がロードできる。実在しない名前は loader が 404 → `error` 状態にする
- * （旧挙動の「黙って solid を出す」黒画面より、明示エラーの方が良 UX）。
+ * `name.trim()` で前後空白を正規化し、小文字化したうえで {@link PATTERN_MAP} を
+ * 引く。既知のニックネームは canonical id へ解決する（不変）。
  *
- * 空白のみ（または空文字）は安全な既定として従来どおり `"solid"` を返す。
+ * 未知名は、**安全な id（{@link SAFE_PATTERN_ID} = `[a-z0-9-]`、先頭は英数字）だと
+ * 確認できた場合のみ**、その名前をファイル名として扱い passthrough する。
+ * `colorbar-simple` のように {@link PATTERN_MAP} 未登録でも
+ * `/patterns/<name>.yaml`（web）/ root `patterns/`（Tauri）から loader がロードできる。
+ * 実在しない名前は loader が 404 → `error` 状態にする（旧挙動の「黙って solid を
+ * 出す」黒画面より、明示エラーの方が良 UX）。
+ *
+ * 一方、`/`・`\`・`.`・`..`・空白・その他の不正文字を含む名前（例
+ * `../../etc/passwd`・`foo/bar`・`a.yaml`）は **passthrough せず安全な既定 `"solid"`
+ * に倒す**。これにより、解決結果が Tauri 側 Rust `pattern_expander.load_pattern_file`
+ * の `patterns_dir.join(path)` に渡って patterns ディレクトリ外の任意 `.yaml` を
+ * 読まれる事故（パストラバーサル・拡張子注入）を遮断する。
+ *
+ * 空白のみ（または空文字）も安全な既定として従来どおり `"solid"` を返す。
  * App.tsx がデフォルト `"colorbar"` を保証するため空文字は実運用で来ないが、防御的に温存する。
  */
 export function resolvePatternId(name: string): string {
@@ -65,7 +83,14 @@ export function resolvePatternId(name: string): string {
   if (normalized === "") {
     return "solid";
   }
-  return PATTERN_MAP[normalized] ?? normalized;
+  // 既知エイリアスは canonical id へ（安全集合のみを値に持つので無条件で許可）。
+  const mapped = PATTERN_MAP[normalized];
+  if (mapped !== undefined) {
+    return mapped;
+  }
+  // 未知名は「安全な id」だと確認できた場合だけファイル名として passthrough。
+  // 不正文字（パストラバーサル・拡張子注入）を含むものは solid に倒す。
+  return SAFE_PATTERN_ID.test(normalized) ? normalized : "solid";
 }
 
 /**

--- a/frontend/src/lib/presetExpander.test.ts
+++ b/frontend/src/lib/presetExpander.test.ts
@@ -1,0 +1,249 @@
+/**
+ * presetExpander — preset/background ノード展開の回帰スイート（Issue #23）。
+ *
+ * `colorbar-simple.yaml` のような `type: background, preset: colorbar` 参照ノードを
+ * 参照先パターンの nodes に in-place 展開する純粋寄り関数 `expandPresets` の挙動を
+ * 固定する。守る仕様:
+ *   - background/preset ノードが getPattern の戻り nodes に置換される
+ *   - nested preset（参照先がさらに preset を持つ）を再帰展開する
+ *   - node.params が getPattern の第2引数へ文字列化して渡る
+ *   - z 順: 展開 nodes は元の位置に in-place 展開され前後関係が保たれる
+ *   - 取得失敗（getPattern reject）は warn して drop、throw しない・他ノードは残る
+ *   - preset 欠落（node.preset 無し）は warn して drop
+ *   - 循環ガード: 自己参照 preset は depth 上限で打ち切り無限ループしない
+ *   - 非 preset ノード（rect 等）はそのまま不変
+ *
+ * getPattern は mock し、console.warn は spy で握って出力を汚さない。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { expandPresets } from "./presetExpander";
+import type { PatternNode, XSGPattern } from "./types";
+
+// ---------------------------------------------------------------------------
+// テスト用ヘルパ
+// ---------------------------------------------------------------------------
+
+/** 任意 fill の rect ノード（プリミティブ本体の代用）。 */
+function rect(id: string, fill: string): PatternNode {
+  return {
+    id,
+    type: "rect",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    fill,
+  } as PatternNode;
+}
+
+/** background 参照ノード（colorbar-simple の bg-colorbar 相当）。 */
+function background(
+  id: string,
+  preset: string,
+  params?: Record<string, unknown>
+): PatternNode {
+  return { id, type: "background", preset, params } as PatternNode;
+}
+
+/** preset 参照ノード。 */
+function preset(
+  id: string,
+  presetId: string,
+  params?: Record<string, unknown>
+): PatternNode {
+  return { id, type: "preset", preset: presetId, params } as PatternNode;
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  // 出力汚染を避けつつ warn 呼び出しを検証できるよう握る。
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+describe("expandPresets", () => {
+  it("background ノードが参照先パターンの nodes に展開される", async () => {
+    // --- 仕様: {type:background, preset:colorbar} → colorbar の rect 群 ---
+    const colorbarNodes = [
+      rect("bar-white", "#C0C0C0"),
+      rect("bar-yellow", "#C0C000"),
+    ];
+    const getPattern = vi.fn(
+      async (): Promise<XSGPattern> => ({
+        canvas: { width: 1920, height: 1080 },
+        nodes: colorbarNodes,
+      })
+    );
+
+    const input: XSGPattern = {
+      canvas: { width: 1920, height: 1080 },
+      nodes: [background("bg-colorbar", "colorbar")],
+    };
+
+    const result = await expandPresets(input, getPattern);
+
+    // 参照先の rect 群がそのまま nodes になる。
+    expect(result.nodes).toEqual(colorbarNodes);
+    // canvas など他フィールドは保持される。
+    expect(result.canvas).toEqual({ width: 1920, height: 1080 });
+    // getPattern は参照先 id と空 params で1回呼ばれる。
+    expect(getPattern).toHaveBeenCalledTimes(1);
+    expect(getPattern).toHaveBeenCalledWith("colorbar", {});
+  });
+
+  it("preset ノードも同様に展開される", async () => {
+    const inner = [rect("a", "#fff")];
+    const getPattern = vi.fn(
+      async (): Promise<XSGPattern> => ({ nodes: inner })
+    );
+    const input: XSGPattern = { nodes: [preset("p", "some-preset")] };
+
+    const result = await expandPresets(input, getPattern);
+
+    expect(result.nodes).toEqual(inner);
+    expect(getPattern).toHaveBeenCalledWith("some-preset", {});
+  });
+
+  it("nested preset を再帰展開する", async () => {
+    // outer は preset:mid を参照、mid はさらに preset:leaf を参照、leaf が rect。
+    const leafNodes = [rect("leaf-rect", "#abc")];
+    const getPattern = vi.fn(async (id: string): Promise<XSGPattern> => {
+      if (id === "mid") {
+        return { nodes: [preset("mid-ref", "leaf")] };
+      }
+      if (id === "leaf") {
+        return { nodes: leafNodes };
+      }
+      throw new Error(`unexpected id: ${id}`);
+    });
+
+    const input: XSGPattern = { nodes: [preset("outer-ref", "mid")] };
+    const result = await expandPresets(input, getPattern);
+
+    // 2段深く展開され、最終的に leaf の rect だけが残る。
+    expect(result.nodes).toEqual(leafNodes);
+    expect(getPattern).toHaveBeenCalledWith("mid", {});
+    expect(getPattern).toHaveBeenCalledWith("leaf", {});
+  });
+
+  it("node.params を文字列化して getPattern の第2引数に渡す", async () => {
+    const getPattern = vi.fn(async (): Promise<XSGPattern> => ({ nodes: [] }));
+    const input: XSGPattern = {
+      nodes: [
+        background("bg", "colorbar", { level: 75, hue: "red", on: true }),
+      ],
+    };
+
+    await expandPresets(input, getPattern);
+
+    // 値はすべて String() 化されて渡る（get_pattern の user_params は文字列前提）。
+    expect(getPattern).toHaveBeenCalledWith("colorbar", {
+      level: "75",
+      hue: "red",
+      on: "true",
+    });
+  });
+
+  it("z 順: background が先頭なら展開 nodes が先頭（背面）に来て後続ノードが続く", async () => {
+    // background(背景) を先頭に、その後に通常 rect(前景) を置く。
+    const bgNodes = [rect("bg-1", "#111"), rect("bg-2", "#222")];
+    const getPattern = vi.fn(
+      async (): Promise<XSGPattern> => ({ nodes: bgNodes })
+    );
+
+    const fg = rect("fg", "#fff");
+    const input: XSGPattern = {
+      nodes: [background("bg", "colorbar"), fg],
+    };
+
+    const result = await expandPresets(input, getPattern);
+
+    // 展開 nodes が in-place（先頭位置）に並び、その後に前景 rect が続く。
+    expect(result.nodes).toEqual([...bgNodes, fg]);
+  });
+
+  it("取得失敗（getPattern reject）は warn して drop、throw せず他ノードは残る", async () => {
+    const fg = rect("fg", "#fff");
+    const getPattern = vi.fn(async (): Promise<XSGPattern> => {
+      throw new Error("not found");
+    });
+    const input: XSGPattern = {
+      nodes: [background("bad", "missing"), fg],
+    };
+
+    // throw せず解決する。
+    const result = await expandPresets(input, getPattern);
+
+    // 失敗 preset は消え、他ノードは残る。
+    expect(result.nodes).toEqual([fg]);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("preset 欠落（node.preset 無し）は warn して drop", async () => {
+    const fg = rect("fg", "#fff");
+    const getPattern = vi.fn(async (): Promise<XSGPattern> => ({ nodes: [] }));
+    const input: XSGPattern = {
+      // preset プロパティを持たない background ノード。
+      nodes: [{ id: "no-ref", type: "background" } as PatternNode, fg],
+    };
+
+    const result = await expandPresets(input, getPattern);
+
+    expect(result.nodes).toEqual([fg]);
+    // 参照先が無いので getPattern は呼ばれない。
+    expect(getPattern).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("循環ガード: 自己参照 preset は depth 上限で打ち切り無限ループしない", async () => {
+    // mock が常に自分（同じ preset 参照）を返す → 再帰が depth 上限で止まる。
+    const getPattern = vi.fn(
+      async (id: string): Promise<XSGPattern> => ({
+        nodes: [preset("self", id)],
+      })
+    );
+    const input: XSGPattern = { nodes: [preset("root", "loop")] };
+
+    const result = await expandPresets(input, getPattern);
+
+    // 最終的に展開できるノードは無くなる（depth 超過で drop）。
+    expect(result.nodes).toEqual([]);
+    // 上限（MAX_DEPTH=16）回前後で打ち切られ、呼び出し回数は有限。
+    expect(getPattern.mock.calls.length).toBeLessThanOrEqual(17);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("非 preset ノード（rect 等）はそのまま不変", async () => {
+    const getPattern = vi.fn(async (): Promise<XSGPattern> => ({ nodes: [] }));
+    const r1 = rect("r1", "#aaa");
+    const r2 = rect("r2", "#bbb");
+    const input: XSGPattern = { nodes: [r1, r2] };
+
+    const result = await expandPresets(input, getPattern);
+
+    // 何も置換されず順序も同じ。getPattern は呼ばれない。
+    expect(result.nodes).toEqual([r1, r2]);
+    expect(getPattern).not.toHaveBeenCalled();
+  });
+
+  it("nodes が未定義/空ならそのまま返す（同一参照）", async () => {
+    const getPattern = vi.fn(async (): Promise<XSGPattern> => ({ nodes: [] }));
+
+    const emptyNodes: XSGPattern = {
+      canvas: { width: 10, height: 10 },
+      nodes: [],
+    };
+    expect(await expandPresets(emptyNodes, getPattern)).toBe(emptyNodes);
+
+    const noNodes: XSGPattern = { canvas: { width: 10, height: 10 } };
+    expect(await expandPresets(noNodes, getPattern)).toBe(noNodes);
+
+    expect(getPattern).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/presetExpander.test.ts
+++ b/frontend/src/lib/presetExpander.test.ts
@@ -5,7 +5,9 @@
  * 参照先パターンの nodes に in-place 展開する純粋寄り関数 `expandPresets` の挙動を
  * 固定する。守る仕様:
  *   - background/preset ノードが getPattern の戻り nodes に置換される
- *   - nested preset（参照先がさらに preset を持つ）を再帰展開する
+ *   - 展開ノードの id はホストノード id で名前空間化される（`${hostId}/${childId}`）
+ *   - nested preset（参照先がさらに preset を持つ）を再帰展開する（prefix が積み上がる）
+ *   - 同一 preset の複数参照でも展開後の全 id が一意（React key 衝突回避）
  *   - node.params が getPattern の第2引数へ文字列化して渡る
  *   - z 順: 展開 nodes は元の位置に in-place 展開され前後関係が保たれる
  *   - 取得失敗（getPattern reject）は warn して drop、throw しない・他ノードは残る
@@ -88,8 +90,11 @@ describe("expandPresets", () => {
 
     const result = await expandPresets(input, getPattern);
 
-    // 参照先の rect 群がそのまま nodes になる。
-    expect(result.nodes).toEqual(colorbarNodes);
+    // 参照先の rect 群が nodes になる。id はホスト 'bg-colorbar' で名前空間化される。
+    expect(result.nodes).toEqual([
+      { ...colorbarNodes[0], id: "bg-colorbar/bar-white" },
+      { ...colorbarNodes[1], id: "bg-colorbar/bar-yellow" },
+    ]);
     // canvas など他フィールドは保持される。
     expect(result.canvas).toEqual({ width: 1920, height: 1080 });
     // getPattern は参照先 id と空 params で1回呼ばれる。
@@ -106,7 +111,8 @@ describe("expandPresets", () => {
 
     const result = await expandPresets(input, getPattern);
 
-    expect(result.nodes).toEqual(inner);
+    // 中身は不変、id だけホスト 'p' で名前空間化される。
+    expect(result.nodes).toEqual([{ ...inner[0], id: "p/a" }]);
     expect(getPattern).toHaveBeenCalledWith("some-preset", {});
   });
 
@@ -126,10 +132,61 @@ describe("expandPresets", () => {
     const input: XSGPattern = { nodes: [preset("outer-ref", "mid")] };
     const result = await expandPresets(input, getPattern);
 
-    // 2段深く展開され、最終的に leaf の rect だけが残る。
-    expect(result.nodes).toEqual(leafNodes);
+    // 2段深く展開され、最終的に leaf の rect だけが残る。id 名前空間は再帰で
+    // prefix が積み上がる: outer-ref（最外ホスト）→ mid-ref（中間ホスト）→ leaf-rect。
+    expect(result.nodes).toEqual([
+      { ...leafNodes[0], id: "outer-ref/mid-ref/leaf-rect" },
+    ]);
     expect(getPattern).toHaveBeenCalledWith("mid", {});
     expect(getPattern).toHaveBeenCalledWith("leaf", {});
+  });
+
+  it("同じ preset を2回参照しても展開後の全ノード id が一意（React key 衝突回避）", async () => {
+    // 参照先 colorbar は同じ id の rect を持つ。host id でしか区別できないので、
+    // 名前空間化が無いと展開後に重複 key（bar-white が2つ等）になる。
+    const colorbarNodes = [
+      rect("bar-white", "#fff"),
+      rect("bar-black", "#000"),
+    ];
+    const getPattern = vi.fn(
+      async (): Promise<XSGPattern> => ({ nodes: colorbarNodes })
+    );
+    const input: XSGPattern = {
+      nodes: [background("bg-a", "colorbar"), background("bg-b", "colorbar")],
+    };
+
+    const result = await expandPresets(input, getPattern);
+
+    const ids = (result.nodes ?? []).map((n) => n.id);
+    // 4 ノードに展開され、それぞれ別ホスト prefix で一意化される。
+    expect(ids).toEqual([
+      "bg-a/bar-white",
+      "bg-a/bar-black",
+      "bg-b/bar-white",
+      "bg-b/bar-black",
+    ]);
+    // 重複なし（new Set のサイズが一致）= React key が衝突しない。
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("ホストノードに id が無い preset はインデックスで一意化される", async () => {
+    // id を持たない preset/background ノード（防御ケース）。
+    const getPattern = vi.fn(
+      async (): Promise<XSGPattern> => ({ nodes: [rect("child", "#abc")] })
+    );
+    const input: XSGPattern = {
+      nodes: [
+        { type: "preset", preset: "p" } as PatternNode,
+        { type: "preset", preset: "p" } as PatternNode,
+      ],
+    };
+
+    const result = await expandPresets(input, getPattern);
+
+    const ids = (result.nodes ?? []).map((n) => n.id);
+    // index 0/1 で一意化され、重複しない。
+    expect(ids).toEqual(["preset-0/child", "preset-1/child"]);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 
   it("node.params を文字列化して getPattern の第2引数に渡す", async () => {
@@ -165,7 +222,12 @@ describe("expandPresets", () => {
     const result = await expandPresets(input, getPattern);
 
     // 展開 nodes が in-place（先頭位置）に並び、その後に前景 rect が続く。
-    expect(result.nodes).toEqual([...bgNodes, fg]);
+    // 展開 nodes の id はホスト 'bg' で名前空間化され、前景 fg はそのまま。
+    expect(result.nodes).toEqual([
+      { ...bgNodes[0], id: "bg/bg-1" },
+      { ...bgNodes[1], id: "bg/bg-2" },
+      fg,
+    ]);
   });
 
   it("取得失敗（getPattern reject）は warn して drop、throw せず他ノードは残る", async () => {

--- a/frontend/src/lib/presetExpander.ts
+++ b/frontend/src/lib/presetExpander.ts
@@ -1,0 +1,135 @@
+/**
+ * Preset / Background ノード展開ユーティリティ
+ *
+ * `colorbar.yaml` のような基底パターンは rect 等のプリミティブで本体を描く。
+ * 一方 `colorbar-simple.yaml` は `type: background, preset: colorbar` という
+ * 「参照ノード」だけを持ち、本体は基底パターンの nodes を借りる。この
+ * preset/background → nodes 展開はレンダラー（`NodeRenderer`）にも `get_pattern`
+ * （Rust / web fallback）にも存在しないため、未対応ノードとして黒落ちしていた
+ * （Issue #23）。
+ *
+ * 規律3（二重実装を作らない）に従い、展開ロジックは TS のこの 1 箇所だけに置く。
+ * Rust 側に同等実装は足さない。`getPattern` を引数で受け取る純粋寄りの関数にし、
+ * Tauri/web どちらのローダ（`safeInvoke("get_pattern", ...)`）でも再利用できるよう
+ * にしてある（呼び元が `tauriCompat.loadResolvedPattern` で結線する）。
+ *
+ * 規律2（定義と状態の分離）: 入力 `XSGPattern` は不変の定義として扱い、状態の
+ * 入れ物に流用しない。展開結果は `{ ...pattern, nodes }` で新しいオブジェクトを
+ * 組み立てて返し、入力を破壊的に変更しない。
+ */
+
+import type { PatternNode, PresetNode, XSGPattern } from "./types";
+
+/**
+ * preset 自己参照・相互参照による無限ループを防ぐ再帰深度の上限。
+ */
+const MAX_DEPTH = 16;
+
+/**
+ * preset/background ノードを参照先パターンの nodes に in-place 展開する。
+ *
+ * `pattern.nodes` を順に走査し、新しい nodes 配列を組む:
+ *   - `type === "background" | "preset"` のとき、`node.preset`（参照先 id）の
+ *     パターンを `getPattern` で取得し、再帰展開した上で、その nodes を **同じ位置**
+ *     に差し込む（z 順保持。background が先頭なら背面に来る）。
+ *   - それ以外のノードはそのまま残す。
+ *
+ * 黒落ちでクラッシュさせないため、参照不能（preset 欠落・取得失敗・深度超過）な
+ * 展開ノードは `console.warn` して **drop** し、他ノードの描画は継続する。
+ *
+ * @param pattern  展開対象パターン（不変。破壊しない）
+ * @param getPattern  参照先 id と params から `XSGPattern` を解決する取得関数
+ *                    （extends/params 解決済みのものを返す前提。Tauri は Rust、
+ *                    web は fetch で解決される）
+ * @param depth  再帰深度（暴走ガード用。呼び元は省略してよい）
+ * @returns 展開後の新しい `XSGPattern`（他フィールドは保持）
+ */
+export async function expandPresets(
+  pattern: XSGPattern,
+  getPattern: (
+    id: string,
+    params: Record<string, string>
+  ) => Promise<XSGPattern>,
+  depth = 0
+): Promise<XSGPattern> {
+  const nodes = pattern.nodes;
+  // nodes が未定義/空ならそのまま返す（展開する余地がない）。
+  if (!nodes || nodes.length === 0) {
+    return pattern;
+  }
+
+  const expandedNodes: PatternNode[] = [];
+
+  for (const node of nodes) {
+    if (node.type === "background" || node.type === "preset") {
+      const presetNode = node as PresetNode;
+      const presetId = presetNode.preset;
+
+      // 参照先 id が無いノードは描けないので drop（黒落ち防止）。
+      if (!presetId) {
+        console.warn(
+          `[expandPresets] node '${node.id}' (type=${node.type}) has no 'preset' reference; dropping`
+        );
+        continue;
+      }
+
+      // 深度上限を超えたら展開を打ち切り、この preset ノードを drop する
+      // （自己参照・相互参照での無限ループ防止）。
+      if (depth >= MAX_DEPTH) {
+        console.warn(
+          `[expandPresets] max depth (${MAX_DEPTH}) exceeded while expanding preset '${presetId}' (node '${node.id}'); dropping to avoid infinite recursion`
+        );
+        continue;
+      }
+
+      // preset 固有パラメータを文字列化する（get_pattern の user_params は
+      // 文字列前提のため）。
+      const params = stringifyParams(presetNode.params);
+
+      try {
+        const presetPattern = await getPattern(presetId, params);
+        // nested preset 対応: 取得したパターン自身が preset/background を
+        // 持つ場合に備えて再帰展開する。
+        const expanded = await expandPresets(
+          presetPattern,
+          getPattern,
+          depth + 1
+        );
+        // 展開 nodes をこの位置に差し込む（z 順保持＝in-place 展開）。
+        for (const child of expanded.nodes ?? []) {
+          expandedNodes.push(child);
+        }
+      } catch (err) {
+        // 取得失敗（fetch 404・コマンド未対応など）は握り、このノードだけ
+        // drop して他ノードの描画は継続する。
+        console.warn(
+          `[expandPresets] failed to resolve preset '${presetId}' (node '${node.id}'); dropping`,
+          err
+        );
+      }
+    } else {
+      // preset 以外のノードはそのまま保持する。
+      expandedNodes.push(node);
+    }
+  }
+
+  return { ...pattern, nodes: expandedNodes };
+}
+
+/**
+ * preset の `params`（`Record<string, unknown>` | undefined）を get_pattern の
+ * user_params 形式（`Record<string, string>`）へ変換する。値は `String()` で
+ * 文字列化する。
+ */
+function stringifyParams(
+  params: Record<string, unknown> | undefined
+): Record<string, string> {
+  if (!params) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(params)) {
+    out[key] = String(value);
+  }
+  return out;
+}

--- a/frontend/src/lib/presetExpander.ts
+++ b/frontend/src/lib/presetExpander.ts
@@ -34,6 +34,17 @@ const MAX_DEPTH = 16;
  *     に差し込む（z 順保持。background が先頭なら背面に来る）。
  *   - それ以外のノードはそのまま残す。
  *
+ * 展開する子ノードの `id` は**ホスト（preset/background）ノードの id で名前空間化**
+ * する（`${hostId}/${childId}`、ホストに id が無ければ `preset-${index}/${childId}`）。
+ * これにより、同じ preset を複数回参照しても、また preset 内 id が兄弟ノード id と
+ * 衝突しても、展開後の id が一意になり、描画側（`PatternCanvas`/`SlideshowView` の
+ * `key={node.id}`）の React duplicate key を防ぐ。再帰展開ではこの prefix が積み上がり
+ * 深い階層でも一意性が保たれる。id 以外（type/座標/fill/z 順 等）は一切変えない。
+ *
+ * ユーザのクエリ params（`?pattern=...&size=...`）は**base パターンにのみ**適用され、
+ * preset 参照の子へは伝播しない。子 preset は YAML 記述の `node.params` のみで
+ * 解決される（preset params は作者固定）。
+ *
  * 黒落ちでクラッシュさせないため、参照不能（preset 欠落・取得失敗・深度超過）な
  * 展開ノードは `console.warn` して **drop** し、他ノードの描画は継続する。
  *
@@ -60,7 +71,9 @@ export async function expandPresets(
 
   const expandedNodes: PatternNode[] = [];
 
+  let index = -1;
   for (const node of nodes) {
+    index += 1;
     if (node.type === "background" || node.type === "preset") {
       const presetNode = node as PresetNode;
       const presetId = presetNode.preset;
@@ -86,6 +99,11 @@ export async function expandPresets(
       // 文字列前提のため）。
       const params = stringifyParams(presetNode.params);
 
+      // 展開ノード id の名前空間 prefix。ホストノード id があればそれを使い、
+      // 無ければインデックスで一意化する。これで同 preset の複数参照でも、
+      // また preset 内 id が兄弟 id と衝突しても、展開後 id が一意になる。
+      const namespacePrefix = node.id ?? `preset-${index}`;
+
       try {
         const presetPattern = await getPattern(presetId, params);
         // nested preset 対応: 取得したパターン自身が preset/background を
@@ -96,8 +114,13 @@ export async function expandPresets(
           depth + 1
         );
         // 展開 nodes をこの位置に差し込む（z 順保持＝in-place 展開）。
+        // 各子ノードの id をホストノード id で名前空間化して一意化する
+        // （type/座標/fill 等の中身は不変、id だけ prefix を付加）。
         for (const child of expanded.nodes ?? []) {
-          expandedNodes.push(child);
+          expandedNodes.push({
+            ...child,
+            id: `${namespacePrefix}/${child.id}`,
+          });
         }
       } catch (err) {
         // 取得失敗（fetch 404・コマンド未対応など）は握り、このノードだけ

--- a/frontend/src/lib/tauriCompat.ts
+++ b/frontend/src/lib/tauriCompat.ts
@@ -43,6 +43,12 @@ export async function safeInvoke<T>(
  * パターン（さらにその extends/params）もモード適切（Tauri=Rust / web=fetch）に
  * 解決されつつ in-place 展開される。
  *
+ * ユーザのクエリ params（`?pattern=...&size=...`）は**base パターンにのみ**適用され、
+ * preset 参照の子へは伝播しない（子の getPattern には base の `params` を渡さない）。
+ * 子 preset は YAML 記述の `node.params` のみで解決される（preset params は作者固定）。
+ * また展開ノードの id はホストノード id で名前空間化されるため、同一 preset を
+ * 複数参照しても描画側の React key（`key={node.id}`）が衝突しない。
+ *
  * 規律3: preset 展開は TS のこの経路 1 箇所だけ。Rust 側には足さない。
  * 描画サイト（usePatternLoader / SlideshowView）は本関数を呼ぶだけでよい。
  */

--- a/frontend/src/lib/tauriCompat.ts
+++ b/frontend/src/lib/tauriCompat.ts
@@ -6,6 +6,9 @@
  * In browser mode, Tauri commands are simulated with web-based fallbacks.
  */
 
+import { expandPresets } from "./presetExpander";
+import type { XSGPattern } from "./types";
+
 /**
  * Check if running inside Tauri webview
  */
@@ -28,6 +31,32 @@ export async function safeInvoke<T>(
 
   // Web-mode fallbacks
   return webFallback<T>(cmd, args);
+}
+
+/**
+ * `get_pattern` でパターンを取得し、preset/background ノードを参照先の nodes に
+ * 展開した「描画可能な」パターンを返す（Issue #23）。
+ *
+ * `safeInvoke("get_pattern", ...)` の戻りは extends 継承と `{{param}}` 置換まで
+ * 解決済みだが、preset/background ノードはそのまま残る。`expandPresets` に
+ * `safeInvoke("get_pattern", ...)` 自身を `getPattern` として渡すことで、参照先
+ * パターン（さらにその extends/params）もモード適切（Tauri=Rust / web=fetch）に
+ * 解決されつつ in-place 展開される。
+ *
+ * 規律3: preset 展開は TS のこの経路 1 箇所だけ。Rust 側には足さない。
+ * 描画サイト（usePatternLoader / SlideshowView）は本関数を呼ぶだけでよい。
+ */
+export async function loadResolvedPattern(
+  patternId: string,
+  params: Record<string, string>
+): Promise<XSGPattern> {
+  const base = await safeInvoke<XSGPattern>("get_pattern", {
+    patternId,
+    params,
+  });
+  return expandPresets(base, (id, p) =>
+    safeInvoke<XSGPattern>("get_pattern", { patternId: id, params: p })
+  );
 }
 
 /**
@@ -112,13 +141,13 @@ async function loadPatternFromWeb(
   }
 
   const yamlText = await response.text();
-  let pattern = yaml.load(yamlText) as Record<string, unknown>;
+  let pattern = yaml.load(yamlText) as XSGPattern;
 
   // Resolve extends
-  pattern = (await resolveExtends(pattern as any)) as Record<string, unknown>;
+  pattern = await resolveExtends(pattern);
 
   // Expand params
-  pattern = expandParams(pattern as any, _params) as Record<string, unknown>;
+  pattern = expandParams(pattern, _params);
 
   return pattern;
 }


### PR DESCRIPTION
## 関連 Issue
closes #23

## 前提の訂正（調査で判明）
Issue 本文は「preset 展開は Rust `pattern_expander.rs` 側にのみ実装され Tauri は正常」としていたが、精読の結果 **Rust にも `background`/`preset` ノードのプリミティブ展開は無い**（`{{param}}` 置換と `extends` 継承マージのみ）。preset/background ノードの展開は Rust/TS/NodeRenderer のどこにも存在せず、未対応ノードとして黒落ちしていた（両モード共通）。本 PR は **TS で1回だけ展開を実装**し（規律3: 二重実装を作らない・Rust に足さない）、両モードを直す。

## 変更内容
### 1. preset/background 展開エンジン（TS・単一実装）
- 新規 `lib/presetExpander.ts` の `expandPresets(pattern, getPattern)`: `nodes` を走査し `type: background`/`preset` を、参照先 preset の nodes で **in-place 置換**（z 順保持）。**nested 再帰**・`node.params` を文字列化して override・取得失敗/preset 欠落/深度上限(16)は `console.warn` で当該ノードを drop（throw せず他ノードは描画継続）。
- `lib/tauriCompat.ts` に `loadResolvedPattern(id, params)` 追加 = `get_pattern` 取得 + `expandPresets`。preset 解決は既存 `safeInvoke("get_pattern")` を再利用するため **Tauri は Rust ローダ / web は fetch でモード適切**に解決される。
- 描画サイト2つ（`hooks/usePatternLoader.ts`・`components/SlideshowView.tsx`）を `loadResolvedPattern` 経由に差し替え。NodeRenderer は変更なし（展開後 preset ノードは残らない＝pure render 維持）。

### 2. パターン到達性の修正（同 Issue の `?pattern=` 単体表示）
- `resolvePatternId` の未知名フォールバックを **`"solid"` 黙殺 → ファイル名パススルー**に変更（`lib/patternId.ts`）。`colorbar-simple` 等のエイリアス未登録パターン（26 YAML 中エイリアス25個）が `?pattern=` から到達可能に。空文字は安全のため従来どおり `"solid"`（App.tsx がデフォルト "colorbar" を保証）。`?pattern=typo` は黒い solid 黙殺でなく明示エラー（良 UX）。

## テスト
- `npm test`: **180 passed**（presetExpander 10件 + 到達性 characterization 更新 + 既存）。`npm run build`（tsc）緑。
- **実ブラウザ検証（Playwright）**: dev サーバで `?pattern=colorbar-simple` を開き、canvas に SMPTE カラーバー（白 192,192,192 / 黄 192,192,0 / シアン 0,192,192 / 緑 0,192,0 / マゼンタ 192,0,192 / 赤 192,0,0）の描画を確認＝**黒落ち解消を end-to-end 実証**。console error は favicon 404 のみ（無関係）。

## docs / follow-up
- `preset-system.md` は丸ごと旧 Python 時代の架空設計（.tsx preset / FastAPI）で実装と全乖離 → #27 で追跡（本 PR では触らない）。
- Tauri 実機の preset 描画目視は #12 の GUI サインオフに合流（web は本 PR で自動確認済み）。
- root `patterns/` と `frontend/public/patterns/` の二重管理は別途。