### PR TITLE
fix: clippy デッドコード警告を解消しクリーンを維持 (#8, closes #29)

### DIFF
--- a/frontend/src-tauri/src/calibration/gamma.rs
+++ b/frontend/src-tauri/src/calibration/gamma.rs
@@ -81,7 +81,7 @@ pub fn restore_gamma() -> ControlResult {
             drop(saved);
             return set_gamma(gamma);
         }
-        return ControlResult::failure("No saved gamma to restore");
+        ControlResult::failure("No saved gamma to restore")
     }
 
     #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]

--- a/frontend/src-tauri/src/calibration/night_mode.rs
+++ b/frontend/src-tauri/src/calibration/night_mode.rs
@@ -1,5 +1,5 @@
 use super::types::{ControlResult, NightModeStatus};
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 use std::process::Command;
 
 /// Detect if night mode / blue light filter is enabled

--- a/frontend/src-tauri/src/calibration/types.rs
+++ b/frontend/src-tauri/src/calibration/types.rs
@@ -11,6 +11,9 @@ pub struct GammaStatus {
 }
 
 impl GammaStatus {
+    // Used by the non-macOS gamma paths (linux xrandr / unsupported-platform fallback);
+    // dead on the macOS build only.
+    #[allow(dead_code)]
     pub fn not_supported(message: impl Into<String>) -> Self {
         Self {
             supported: false,

--- a/frontend/src/lib/patternRegistry.ts
+++ b/frontend/src/lib/patternRegistry.ts
@@ -151,7 +151,7 @@ export async function loadPattern(id: string): Promise<PatternModule | null> {
     const module = await import(`/patterns/${id}.tsx`);
     registry.register(id, module);
     return module;
-  } catch (e) {
+  } catch {
     // Try legacy location
     try {
       const module = await import(`../components/patterns/${id}.tsx`);


### PR DESCRIPTION
## 関連 Issue
closes #8
closes #29

## 概要
`cargo clippy --all-targets -- -D warnings` のデッドコード/未使用警告3件 + TS 未使用変数1件を解消し、clippy をクリーンに（CI #3 のゲートと整合）。**#29（calibration clippy 3件）を内包**。

## 重要な所見: 大半は「削除」でなく「プラットフォーム条件付きの正しい抑制」
監査が言う「Tauri 移行残骸のデッドコード多数」は session702 等で概ね解消済みで、残る clippy 警告は **macOS ビルドでのみ dead に見える cross-platform コード**だった。素朴に削除すると Linux/Windows が壊れるため、cfg-gate / `#[allow(dead_code)]` で正しく抑制した（挙動不変）。

## 変更（4ファイル +6/-3・ロジック改変なし）
- **`types.rs`**: `GammaStatus::not_supported` に `#[allow(dead_code)]` + コメント。実使用は `gamma.rs:31`（unsupported-platform fallback）と `gamma.rs:278`（linux xrandr）＝macOS でのみ dead。sibling（NightModeStatus/HDRStatus）と同じ確立済みパターン。**削除しない**。
- **`night_mode.rs`**: `use std::process::Command` の cfg を `any(linux, macos)` → `linux` に限定。Command は linux 関数でのみ使用（macOS はスタブ・Windows は winreg）。
- **`gamma.rs`**: macOS ブロック tail の不要 `return` を式化（等価）。
- **`patternRegistry.ts`**: 未使用 catch 変数 `e` を省略（`catch {}`）。真の未使用（内側 catch の `e2` のみ使用）。

## 温存したもの（誤削除しない）
- `types.rs` 既存3つの `#[allow(dead_code)]`（NightModeStatus/HDRStatus の platform 抑制）= 正当。
- `playlist/runner.rs` の generator コメントアウト・各種 TODO = **#21 等の将来機能の統合点マーカー**。

## 検証
- **`cargo clippy --all-targets -- -D warnings`: exit 0・警告ゼロ**（macOS）。cfg-gate/allow なので Linux/Windows でも無破壊（allow は使用中コードには無害、Command は linux で使用継続）。
- `cargo test`: 11 passed（golden_e2e）。`cargo build` / `cargo fmt --check` 緑。
- `patternRegistry.ts` の eslint エラー解消。`npm run build`（tsc）緑。
- 挙動不変のためテスト追加なし（既存 golden_e2e + clippy/build が安全網）。docs に該当言及なし。