### PR TITLE
docs: path-resolution / preset-system を現行 TS 実装に改訂し旧 Python 記述を破棄 (#27)

### DIFF
--- a/docs/design/path-resolution.md
+++ b/docs/design/path-resolution.md
@@ -1,414 +1,174 @@
 # XSG パス解決仕様
 
-## 📁 画像ファイルパスの解決ルール
+> ⚠️ **この文書は現行実装（Tauri + TypeScript）に合わせて 2026-06 に改訂した。**
+> 旧版は存在しない Python バックエンド（`backend/app/path_resolver.py`・`uv run python -m app.main` CLI・pytest）を前提に書かれていたが、その設計は破棄された。現行の座標／パス解決はすべて TypeScript 実装（`frontend/src/lib/pathResolver.ts` ほか）が正本である。Python 実装は存在しない。
 
-### 対応する形式
+XSG のパス解決には 2 系統ある。
+
+1. **画像ファイルパスの解決**（`src` 属性 → 実 URL／ファイルパス）
+2. **座標の解決**（`x`/`y` 等 → ピクセル値。`%`・`calc()` を含む）
+
+両方とも `frontend/src/lib/pathResolver.ts` に実装されている。
+
+---
+
+## 1. 画像ファイルパスの解決
+
+### 正本
+
+- 実装: `frontend/src/lib/pathResolver.ts` の `class PathResolver` ＋ 便宜関数 `resolvePath(path, options?)` / `getPathResolver(options?)`
+- 呼び出し元: `frontend/src/components/SlideshowView.tsx`（L241 `resolvePath(source.src)`）でスライドショーの画像 `src` を解決している。
+  - 注意: 単体ノードを描く `NodeRenderer.tsx` の `renderImage` は現状 `img.src = node.src`（L463）と **生の `src` をそのまま** `<img>` に渡している（`resolvePath` を経由しない）。`@/`・相対パスの正規化は SlideshowView 経路でのみ効く。これは既知の非対称で、image ノードのパス正規化を全描画経路に通すかは要検討。
+
+### 対応する 4 形式
+
+`PathResolver.resolve(path)` は次の順で判定する（`resolve` メソッド本体）。
 
 ```yaml
-# 1. 相対パス（推奨）
-src: "./images/fg/crosstalk.png"
-src: "../shared/logo.png"
-
-# 2. 絶対パス（Windows/Linux/macOS）
-src: "/home/user/images/test.png"         # Linux/macOS
-src: "C:\\Users\\user\\images\\test.png"  # Windows
-
-# 3. プロジェクト相対（@プレフィックス）
-src: "@/images/fg/crosstalk.png"          # プロジェクトルートから
-
-# 4. URL（HTTP/HTTPS）
+# 1. URL（HTTP/HTTPS）— そのまま返す
 src: "https://example.com/images/test.png"
-```
 
----
-
-## 🎯 カレントディレクトリの定義
-
-### ルール: **YAMLファイルが置かれているディレクトリ**
-
-```
-プロジェクト構造:
-xsg/
-├── patterns/
-│   ├── test1.yaml          ← カレント: patterns/
-│   └── subdir/
-│       └── test2.yaml      ← カレント: patterns/subdir/
-├── images/
-│   ├── fg/
-│   │   └── crosstalk.png
-│   └── bg/
-│       └── checker.png
-└── presets/
-```
-
-### 例1: `patterns/test1.yaml`
-
-```yaml
-nodes:
-  - type: image
-    src: "./images/fg/crosstalk.png" # ❌ 解決失敗
-    # 実際のパス: patterns/images/fg/crosstalk.png（存在しない）
-
-  - type: image
-    src: "../images/fg/crosstalk.png" # ✅ 解決成功
-    # 実際のパス: images/fg/crosstalk.png
-```
-
-### 例2: `patterns/subdir/test2.yaml`
-
-```yaml
-nodes:
-  - type: image
-    src: "../../images/fg/crosstalk.png" # ✅ 解決成功
-    # 実際のパス: images/fg/crosstalk.png
-```
-
----
-
-## 🔧 プロジェクト相対パス（@プレフィックス）
-
-### 推奨: プロジェクトルートからの相対パス
-
-```yaml
-# @/ = プロジェクトルート
-- type: image
-  src: "@/images/fg/crosstalk.png"
-# どのYAMLファイルからでも同じパスで参照可能
-```
-
-### プロジェクトルートの検出方法
-
-**優先順位:**
-
-1. `--project-root` コマンドライン引数
-2. `XSG_PROJECT_ROOT` 環境変数
-3. `package.json` が存在するディレクトリ
-4. `pyproject.toml` が存在するディレクトリ
-5. `.git/` が存在するディレクトリ
-6. カレントワーキングディレクトリ
-
-```bash
-# 明示的に指定
-uv run python -m app.main --file patterns/test.yaml --project-root /path/to/xsg
-
-# 環境変数
-export XSG_PROJECT_ROOT=/path/to/xsg
-uv run python -m app.main --file patterns/test.yaml
-
-# 自動検出（package.json or pyproject.toml）
-uv run python -m app.main --file patterns/test.yaml
-```
-
----
-
-## 📋 パス解決の実装
-
-```python
-# backend/app/path_resolver.py
-from pathlib import Path
-import os
-
-class PathResolver:
-    def __init__(self, pattern_file: Path, project_root: Path = None):
-        """
-        Args:
-            pattern_file: YAMLファイルのパス
-            project_root: プロジェクトルート（オプション）
-        """
-        self.pattern_file = pattern_file
-        self.pattern_dir = pattern_file.parent  # YAMLのディレクトリ = カレント
-        self.project_root = project_root or self._detect_project_root()
-
-    def _detect_project_root(self) -> Path:
-        """プロジェクトルートを自動検出"""
-        # 1. 環境変数
-        if env_root := os.getenv("XSG_PROJECT_ROOT"):
-            return Path(env_root)
-
-        # 2. package.json / pyproject.toml を探す
-        current = self.pattern_dir
-        while current != current.parent:
-            if (current / "package.json").exists() or \
-               (current / "pyproject.toml").exists():
-                return current
-            current = current.parent
-
-        # 3. .git/ を探す
-        current = self.pattern_dir
-        while current != current.parent:
-            if (current / ".git").exists():
-                return current
-            current = current.parent
-
-        # 4. カレントワーキングディレクトリ
-        return Path.cwd()
-
-    def resolve(self, path: str) -> Path:
-        """
-        パスを解決する
-
-        Args:
-            path: src属性の値
-
-        Returns:
-            解決された絶対パス
-        """
-        # 1. URL（HTTP/HTTPS）
-        if path.startswith(("http://", "https://")):
-            return path  # URLはそのまま返す
-
-        # 2. プロジェクト相対（@/）
-        if path.startswith("@/"):
-            rel_path = path[2:]  # @/ を削除
-            return self.project_root / rel_path
-
-        # 3. 絶対パス
-        if Path(path).is_absolute():
-            return Path(path)
-
-        # 4. 相対パス（YAMLファイルからの相対）
-        return (self.pattern_dir / path).resolve()
-
-    def exists(self, path: str) -> bool:
-        """パスが存在するか確認"""
-        if path.startswith(("http://", "https://")):
-            return True  # URLは存在チェックしない（実行時にエラー）
-
-        resolved = self.resolve(path)
-        return resolved.exists()
-```
-
----
-
-## 🧪 テストケース
-
-```python
-# tests/test_path_resolver.py
-import pytest
-from pathlib import Path
-from app.path_resolver import PathResolver
-
-def test_relative_path():
-    """相対パス"""
-    pattern_file = Path("/home/user/xsg/patterns/test.yaml")
-    resolver = PathResolver(pattern_file)
-
-    # ../images/fg/test.png
-    result = resolver.resolve("../images/fg/test.png")
-    assert result == Path("/home/user/xsg/images/fg/test.png")
-
-def test_absolute_path():
-    """絶対パス"""
-    pattern_file = Path("/home/user/xsg/patterns/test.yaml")
-    resolver = PathResolver(pattern_file)
-
-    # /tmp/test.png
-    result = resolver.resolve("/tmp/test.png")
-    assert result == Path("/tmp/test.png")
-
-def test_project_relative():
-    """プロジェクト相対"""
-    pattern_file = Path("/home/user/xsg/patterns/test.yaml")
-    project_root = Path("/home/user/xsg")
-    resolver = PathResolver(pattern_file, project_root)
-
-    # @/images/fg/test.png
-    result = resolver.resolve("@/images/fg/test.png")
-    assert result == Path("/home/user/xsg/images/fg/test.png")
-
-def test_url():
-    """URL"""
-    pattern_file = Path("/home/user/xsg/patterns/test.yaml")
-    resolver = PathResolver(pattern_file)
-
-    # https://example.com/test.png
-    result = resolver.resolve("https://example.com/test.png")
-    assert result == "https://example.com/test.png"
-```
-
----
-
-## 📖 使用例
-
-### ケース1: プロジェクト標準レイアウト
-
-```
-xsg/
-├── patterns/
-│   └── test.yaml
-└── images/
-    ├── fg/
-    └── bg/
-```
-
-```yaml
-# patterns/test.yaml
-nodes:
-  - type: image
-    src: "@/images/fg/crosstalk.png" # ✅ 推奨（どこからでも同じ）
-```
-
-### ケース2: 相対パス
-
-```yaml
-# patterns/test.yaml
-nodes:
-  - type: image
-    src: "../images/fg/crosstalk.png" # ✅ OK（シンプル）
-```
-
-### ケース3: 絶対パス
-
-```yaml
-# patterns/test.yaml
-nodes:
-  - type: image
-    src: "/home/user/assets/test.png" # ✅ OK（外部リソース）
-```
-
-### ケース4: URL
-
-```yaml
-# patterns/test.yaml
-nodes:
-  - type: image
-    src: "https://cdn.example.com/test.png" # ✅ OK（リモート）
-```
-
----
-
-## ⚠️ エラーハンドリング
-
-```python
-def load_pattern(pattern_file: Path):
-    resolver = PathResolver(pattern_file)
-
-    for node in pattern["nodes"]:
-        if node.get("type") == "image":
-            src = node["src"]
-
-            # 存在チェック（URLは除く）
-            if not resolver.exists(src):
-                raise FileNotFoundError(
-                    f"Image not found: {src}\n"
-                    f"Resolved to: {resolver.resolve(src)}\n"
-                    f"Pattern file: {pattern_file}\n"
-                    f"Project root: {resolver.project_root}"
-                )
-```
-
-**エラーメッセージ例:**
-
-```
-Image not found: ./images/fg/test.png
-Resolved to: /home/user/xsg/patterns/images/fg/test.png
-Pattern file: /home/user/xsg/patterns/test.yaml
-Project root: /home/user/xsg
-
-Hint: Did you mean "@/images/fg/test.png" or "../images/fg/test.png"?
-```
-
----
-
-## 🎯 推奨パターン
-
-### ✅ 推奨: プロジェクト相対（@/）
-
-```yaml
+# 2. プロジェクト相対（@/ プレフィックス）
 src: "@/images/fg/crosstalk.png"
-```
 
-**メリット:**
+# 3. 絶対パス（Windows / UNC / Unix）
+src: "/home/user/images/test.png"
+src: "C:\\Users\\user\\images\\test.png"
 
-- どのYAMLファイルからも同じパスで参照可能
-- YAMLファイルを移動しても動作する
-- 最も分かりやすい
-
-### ✅ OK: 相対パス
-
-```yaml
+# 4. 相対パス（YAML ファイルのディレクトリ基準）
 src: "../images/fg/crosstalk.png"
 ```
 
-**メリット:**
+判定ロジック（private メソッド）:
 
-- シンプル
-- プロジェクトルートの検出が不要
+| 形式 | 判定 | 解決先 |
+| --- | --- | --- |
+| URL | `isUrl` = `/^https?:\/\//i` | そのまま返す |
+| `@/...` | `path.startsWith("@/")` → `resolveProjectRelative` | `${baseUrl}/<@/ 以降>` |
+| 絶対 | `isAbsolutePath`（`[A-Za-z]:[\\/]` / `^\\\\` / 先頭 `/`） → `resolveAbsolute` | `${baseUrl}/api/file?path=<encoded>`（バックエンド経由の想定 API） |
+| 相対 | 上記いずれも非該当 → `resolveRelative` | `currentFileDir` と結合（`combinePaths` が `.`/`..` を解決） |
 
-**デメリット:**
+`baseUrl` の既定は `window.location.origin`。`PathResolverOptions`（`currentFilePath` / `projectRoot` / `baseUrl`）で上書きできる。
 
-- YAMLファイルを移動すると動作しなくなる
+### 相対パスのカレントディレクトリ
 
-### ✅ OK: 絶対パス（外部リソース）
+相対パスの基準は **YAML ファイルが置かれているディレクトリ**（`currentFileDir`）。`PathResolverOptions.currentFilePath` から `getDirectory` で算出する。`combinePaths` がセグメントを走査し、`..` で 1 段上がり、`.` を捨て、それ以外を積む（純粋な文字列計算で、ファイルシステムには触れない）。
+
+```
+patterns/
+├── test1.yaml          → 相対の基準: patterns/
+└── subdir/test2.yaml   → 相対の基準: patterns/subdir/
+```
+
+- `patterns/test1.yaml` の `src: "../images/fg/x.png"` → `images/fg/x.png`
+- `patterns/subdir/test2.yaml` の `src: "../../images/fg/x.png"` → `images/fg/x.png`
+
+### プロジェクトルート検出（`@/`）
+
+`@/` はプロジェクトルート相対を意図する。ただしブラウザは直接ファイルシステムを読めないため、`detectProjectRoot()` は **ブラウザ文脈では `null` を返す**（コメント済み）。実際の `resolveProjectRelative` は `@/` を外して `${baseUrl}/<rest>` を組むだけで、`projectRoot` の有無で挙動は変わらない。`PathResolverOptions.projectRoot`（または `setProjectRoot`）で値を渡せる契約は残しているが、解決結果には現状ほぼ寄与しない。
+
+> 旧版が列挙していた検出優先順位（`--project-root` 引数・`XSG_PROJECT_ROOT` 環境変数・`package.json`/`pyproject.toml`/`.git` 走査）は **Python CLI 前提の設計で、現行 TS 実装には存在しない**。`pathResolver.ts` の JSDoc には検出候補としてコメントが残るが、ブラウザ実装では `null` 固定である。
+
+### 実 YAML 例
+
+`frontend/public/patterns/image-example.yaml` が 3 形式を実演する。
 
 ```yaml
-src: "/mnt/shared/assets/test.png"
-```
-
-**用途:**
-
-- 共有ディレクトリのリソース
-- 外部ストレージ
-
-### ✅ OK: URL
-
-```yaml
-src: "https://cdn.example.com/test.png"
-```
-
-**用途:**
-
-- CDN
-- リモートリソース
-
----
-
-## 🔄 移植元との互換性
-
-### 移植元の仕様
-
-```javascript
-// 移植元
-{
-  "image_id": "fg/クロストーク"  // 拡張子なし、相対パス
-}
-```
-
-### 新仕様での対応
-
-```yaml
-# 新仕様（推奨）
-src: "@/images/fg/クロストーク.png"
-
-# 移行ツールでの変換
-# image_id: "fg/クロストーク" → src: "@/images/fg/クロストーク.png"
-```
-
-```python
-# migration.py
-def convert_image_id(image_id: str) -> str:
-    """移植元のimage_idを新形式に変換"""
-    # 拡張子がない場合は .png を追加
-    if not any(image_id.endswith(ext) for ext in [".png", ".jpg", ".gif", ".bmp"]):
-        image_id = f"{image_id}.png"
-
-    # プロジェクト相対に変換
-    return f"@/images/{image_id}"
-
-# 例:
-# "fg/クロストーク" → "@/images/fg/クロストーク.png"
-# "bg/sandstorm" → "@/images/bg/sandstorm.png"
+nodes:
+  - id: img-1
+    type: image
+    src: "@/images/logo.png"      # プロジェクト相対
+    x: 100
+    y: 100
+    fit: contain
+    width: 400
+    height: 300
+  - id: img-2
+    type: image
+    src: "https://picsum.photos/400/300"  # URL
+    x: calc(50% + 50px)
+    y: 200
+    scale: 0.5
+  - id: img-3
+    type: image
+    src: "../images/test.png"     # 相対
+    x: 50%
+    y: 50%
+    width: 300
+    height: 300
 ```
 
 ---
 
-## 📋 まとめ
+## 2. 座標の解決（`x`/`y` 等）
 
-| パス形式         | 例                             | カレント                   | 推奨度             |
-| ---------------- | ------------------------------ | -------------------------- | ------------------ |
-| プロジェクト相対 | `@/images/test.png`            | プロジェクトルート         | ⭐⭐⭐             |
-| 相対パス         | `../images/test.png`           | YAMLファイルのディレクトリ | ⭐⭐               |
-| 絶対パス         | `/home/user/test.png`          | -                          | ⭐（外部リソース） |
-| URL              | `https://example.com/test.png` | -                          | ⭐（リモート）     |
+### 正本
 
-**デフォルト推奨: プロジェクト相対（@/）**
+`frontend/src/lib/pathResolver.ts` の以下の **公開 API**:
+
+- `type CoordinateValue = { type: "absolute"; value } | { type: "percentage"; value } | { type: "calc"; expr }`
+- `parseCoordinate(coord: number | string): CoordinateValue`
+- `evaluateCoordinate(coord: number | string, containerSize: number): number`
+
+評価の本体 `evaluateCalcExpression` と算術パーサ `evaluateArithmetic` は **モジュール内 private**（export していない）。外から触る入口は `parseCoordinate` / `evaluateCoordinate` の 2 つ。
+
+利用側: `NodeRenderer.tsx` の `evalCoord(coord, containerSize)` が `evaluateCoordinate` を呼び、各ノードの座標をピクセルに落として Canvas 2D で描画する。`containerSize` は描画時の `canvas.width` / `canvas.height`（ウィンドウサイズ）。
+
+### `parseCoordinate`
+
+| 入力 | 結果 |
+| --- | --- |
+| `number`（例 `100`） | `{ type: "absolute", value: 100 }` |
+| `"50%"` | `{ type: "percentage", value: 50 }` |
+| `"calc(50% + 10px)"` | `{ type: "calc", expr: "50% + 10px" }` |
+| その他文字列 | `parseFloat` で `absolute`（パース不能なら `value: 0`） |
+
+### `evaluateCoordinate`
+
+```
+absolute   → value
+percentage → (value / 100) * containerSize
+calc       → evaluateCalcExpression(expr, containerSize)
+```
+
+### `evaluateCalcExpression`（private）
+
+1. 式中の `<数値>%` を `(percentage/100)*containerSize` の px へ正規化（正規表現置換）。
+2. `px` 単位を除去。
+3. 残った純粋な算術式を `evaluateArithmetic` で評価。
+
+### `evaluateArithmetic`（private・安全な算術パーサ）
+
+**#4 で `eval()` から置き換えた、再帰下降パーサ**。`eval()`／`Function` を使わないことで、敵対的なパターンファイルが座標式経由でコードを注入することを防ぐ。
+
+- トークナイザが受理するのは **数値・`+ - * /`・`(` `)`・空白のみ**。識別子・関数呼び出し・`,`・`;` 等が来たら式全体を棄却する。
+- 文法（左結合・標準の優先順位）:
+  ```
+  expression := term (('+' | '-') term)*
+  term       := factor (('*' | '/') factor)*
+  factor     := ('+' | '-') factor | '(' expression ')' | number
+  ```
+- 解析失敗（不正文字・不完全な式・末尾ゴミ）は `0` を返す（旧 `catch { return 0 }` 互換）。
+- 解析成功でも結果が非有限（0 除算 → `Infinity`、`0/0` → `NaN`）なら **意図的に `0` に丸める**（旧 eval は Infinity/NaN を素通ししていた点からの安全側の差分）。
+
+スキーマ上の `Coordinate` 制約（`xsg-pattern.schema.json` の `definitions.Coordinate`）は `^(\d+(\.\d+)?%|calc\(.+\))$` または `number`。`%`・`calc()`・数値以外の文字列は弾かれる。
+
+---
+
+## 3. repeat オフセットの計算（補足）
+
+ノードの `repeat`（`grid` / `tile` / CSS 風 `repeat`/`repeat-x`/...）からタイル配置オフセットを生成する純粋計算 `calculateRepeatOffsets` は **`pathResolver.ts` ではなく `frontend/src/components/NodeRenderer.tsx`** にある。座標解決とは別レイヤ（描画時のタイル展開）なので、ここでは存在場所だけ示す。詳細は `web-rendering.md` を参照。
+
+---
+
+## 関連ドキュメント
+
+- スキーマの直交設計: `schema-orthogonality.md`
+- Web/Canvas 描画: `web-rendering.md`
+- preset/extends 展開: `preset-system.md`
+
+---
+
+## 履歴
+
+当初は Python バックエンド（FastAPI + `uv run python -m app.main` CLI、`PathResolver` クラス、pytest）でパス解決する設計だった。実装は Tauri（Rust コマンド）＋ TypeScript フロントへ移行し、座標・パス解決は `frontend/src/lib/pathResolver.ts` に集約された。本文書はその現行 TS 実装を記述する。旧 Python 設計の詳細は破棄した。

--- a/docs/design/path-resolution.md
+++ b/docs/design/path-resolution.md
@@ -45,7 +45,7 @@ src: "../images/fg/crosstalk.png"
 | --- | --- | --- |
 | URL | `isUrl` = `/^https?:\/\//i` | そのまま返す |
 | `@/...` | `path.startsWith("@/")` → `resolveProjectRelative` | `${baseUrl}/<@/ 以降>` |
-| 絶対 | `isAbsolutePath`（`[A-Za-z]:[\\/]` / `^\\\\` / 先頭 `/`） → `resolveAbsolute` | `${baseUrl}/api/file?path=<encoded>`（バックエンド経由の想定 API） |
+| 絶対 | `isAbsolutePath`（`[A-Za-z]:[\\/]` / `^\\\\` / 先頭 `/`） → `resolveAbsolute` | `${baseUrl}/api/file?path=<encoded>`（**この `/api/file` エンドポイントは現状未実装**。`resolveAbsolute` は URL 文字列を組むだけで、絶対パス画像を実際に配信する経路はまだ無い） |
 | 相対 | 上記いずれも非該当 → `resolveRelative` | `currentFileDir` と結合（`combinePaths` が `.`/`..` を解決） |
 
 `baseUrl` の既定は `window.location.origin`。`PathResolverOptions`（`currentFilePath` / `projectRoot` / `baseUrl`）で上書きできる。

--- a/docs/design/preset-system.md
+++ b/docs/design/preset-system.md
@@ -1,492 +1,184 @@
-# プリセット＝プラグイン アーキテクチャ
+# プリセットシステム
 
-## 🎯 設計哲学
-
-**「組み込みプリセットはない。全てがプラグインである。」**
-
-これはVSCode、Neovim、Emacsなどの設計哲学と同じです：
-
-- VSCode: 組み込み機能もextensionとして実装
-- Neovim: 組み込み機能もプラグインとして実装
-- Emacs: 組み込み機能もパッケージとして実装
-
-XSGでも同じアプローチを取ります。
+> ⚠️ **この文書は現行実装（YAML プリセット + TypeScript 展開）に合わせて 2026-06 に改訂した。**
+> 旧版は存在しない設計（プリセット＝React `.tsx` コンポーネント、`backend/app/presets.py` の FastAPI 自動検出、`GET /api/presets`、`presets/` ディレクトリ）を前提に書かれていたが、その設計は破棄された。現行のプリセットは **YAML パターンファイル**であり、`type: background | preset` ノードから参照され、TypeScript（`frontend/src/lib/presetExpander.ts`）が展開する。`.tsx` プリセットも presets API も存在しない。
 
 ---
 
-## 📁 プロジェクト構造
+## 設計の要点
 
-```
-xsg/
-├── presets/                    ← 全てのプリセットが平等
-│   ├── checker.tsx             ✅ 「標準」プリセット（リポジトリに含まれる）
-│   ├── colorbar.tsx            ✅ 「標準」プリセット
-│   ├── grayscale.tsx           ✅ 「標準」プリセット
-│   ├── pixeldefect.tsx         ✅ 「標準」プリセット
-│   ├── my-custom.tsx           ✅ ユーザーのカスタムプリセット
-│   └── company-logo.tsx        ✅ ユーザーのカスタムプリセット
-├── patterns/
-│   └── test.yaml
-├── frontend/
-└── backend/
-```
+XSG に「組み込みプリセット」と「ユーザープリセット」の区別はない。**すべてのプリセットは普通の YAML パターンファイル**であり、リポジトリに同梱されているか否かの差しかない。
 
-**重要:**
+- プリセットの実体: `frontend/public/patterns/*.yaml`（web が `fetch`）／ リポジトリルートの `patterns/*.yaml`（Tauri/Rust が読む）。両者は同じファイル群。
+- あるパターンが別パターンを「プリセット」として使うには、`{ type: background | preset, preset: "<id>", params: {...} }` ノードを置く。
+- そのノードは描画時に **参照先パターンの nodes へ in-place 展開**される（`expandPresets`）。
 
-- ❌ 「組み込み」と「カスタム」の区別はない
-- ✅ 全てのプリセットは `presets/` に配置される
-- ✅ リポジトリに含まれているか否かの違いだけ
-- ✅ 実装は全て同じ規約に従う
+`.tsx` コンポーネント・FastAPI 自動検出・Hot Reload する React プリセットは、いずれも現行実装に存在しない。
 
 ---
 
-## 🔧 プリセットの規約
+## プリセット参照ノード
 
-### 基本形式
+`frontend/src/lib/types.ts` に 2 つの参照ノード型がある（中身は同形）。
 
-```typescript
-// presets/checker.tsx
-import { useEffect, useRef } from 'react';
-import type { PresetProps } from '@/lib/presets';
-
-export default function Checker({ params }: PresetProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    const size = params.size || 50;
-    const color1 = params.color1 || '#000000';
-    const color2 = params.color2 || '#FFFFFF';
-
-    // 描画ロジック
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-
-    const cols = Math.ceil(canvas.width / size);
-    const rows = Math.ceil(canvas.height / size);
-
-    for (let row = 0; row < rows; row++) {
-      for (let col = 0; col < cols; col++) {
-        ctx.fillStyle = (row + col) % 2 === 0 ? color1 : color2;
-        ctx.fillRect(col * size, row * size, size, size);
-      }
-    }
-  }, [params]);
-
-  return <canvas ref={canvasRef} className="w-full h-full" />;
+```ts
+interface BackgroundNode extends BaseNode {
+  type: "background";
+  preset: string;                      // 参照先パターン id
+  params?: Record<string, unknown>;    // プリセット固有パラメータ
 }
-
-// メタデータ（オプション）
-export const metadata = {
-  name: "Checker",
-  description: "市松模様パターン",
-  author: "XSG Team",
-  version: "1.0.0",
-  params: {
-    size: { type: "number", default: 50, min: 1, max: 500 },
-    color1: { type: "color", default: "#000000" },
-    color2: { type: "color", default: "#FFFFFF" },
-  },
-};
+interface PresetNode extends BaseNode {
+  type: "preset";
+  preset: string;
+  params?: Record<string, unknown>;
+}
 ```
 
----
+スキーマ正本は `xsg-pattern.schema.json` の `BackgroundNode` / `PresetNode`（どちらも `required: ["preset"]`）。`type` が `background` か `preset` かの違いだけで、展開ロジックは同一に扱う（背面に置きたいものを `background`、前景に重ねたいものを `preset` と書き分ける慣習）。
 
-## 🔍 プリセットの自動検出
+### 実 YAML 例
 
-```typescript
-// backend/app/presets.py
-from pathlib import Path
-import json
-
-def discover_presets(presets_dir: Path = None):
-    """
-    presets/ ディレクトリから全プリセットを自動検出
-
-    「組み込み」と「カスタム」の区別はしない。
-    全て同じ仕組みで扱う。
-    """
-    if presets_dir is None:
-        presets_dir = Path(__file__).parent.parent.parent / "presets"
-
-    presets = {}
-
-    if presets_dir.exists():
-        for file in presets_dir.glob("*.tsx"):
-            preset_name = file.stem  # ファイル名（拡張子なし）
-
-            # メタデータを抽出（オプション）
-            metadata = extract_metadata(file)
-
-            presets[preset_name] = {
-                "name": preset_name,
-                "path": str(file),
-                "metadata": metadata,
-            }
-
-    return presets
-
-def extract_metadata(file: Path):
-    """
-    .tsxファイルから export const metadata を抽出
-    """
-    # 簡易実装: 正規表現でJSONを抽出
-    content = file.read_text()
-    # TODO: より堅牢なパース実装
-    return {}
-
-# FastAPI endpoint
-@app.get("/api/presets")
-async def list_presets():
-    """全プリセット一覧を返す（「組み込み」の区別なし）"""
-    presets = discover_presets()
-    return {
-        "presets": list(presets.values())
-    }
-```
-
----
-
-## 📦 標準プリセットの配布
-
-### リポジトリに含まれる「標準」プリセット
-
-これらはあくまで**リポジトリに同梱されているプリセット**であり、特別扱いはしない：
-
-```
-presets/
-├── checker.tsx         # 市松模様
-├── colorbar.tsx        # SMPTEカラーバー
-├── ebu-colorbar.tsx    # EBUカラーバー
-├── arib-colorbar.tsx   # ARIBカラーバー
-├── grayscale.tsx       # グレースケール
-├── gradient.tsx        # グラデーション
-├── crosshatch.tsx      # クロスハッチ
-├── pixeldefect.tsx     # 画素欠け
-├── multiburst.tsx      # マルチバースト
-├── convergence.tsx     # コンバージェンス
-└── pluge.tsx           # PLUGE
-```
-
-**ユーザーは自由に:**
-
-- ✅ 削除できる（不要なプリセットを削除）
-- ✅ 編集できる（標準プリセットを改造）
-- ✅ 追加できる（独自プリセットを追加）
-
----
-
-## 🎨 使用例
-
-### パターンファイル
+`frontend/public/patterns/colorbar-simple.yaml` — `colorbar` プリセットを背景に敷くだけのパターン:
 
 ```yaml
-# patterns/test.yaml
 canvas:
   width: 1920
   height: 1080
-
 nodes:
-  # 「標準」プリセット（リポジトリに含まれる）
-  - type: background
-    preset: checker # presets/checker.tsx
+  - id: bg-colorbar
+    type: background
+    preset: colorbar        # → colorbar.yaml の nodes を借りる
+```
+
+参照先 `colorbar.yaml` はプリミティブ（`rect` 群）で本体を描く基底パターン:
+
+```yaml
+canvas: { width: 1920, height: 1080 }
+nodes:
+  - id: bar-white
+    type: rect
+    x: 0
+    y: 0
+    width: 274.3
+    height: 1080
+    fill: "#C0C0C0"
+  # ... 残りの色バー
+```
+
+`frontend/public/patterns/checker-with-dot.yaml` — 背景プリセット ＋ 前景の生ノードを重ねる:
+
+```yaml
+nodes:
+  - id: bg-checker
+    type: background
+    preset: checker
     params:
       size: 50
-      color1: "#000000"
-      color2: "#FFFFFF"
-
-  # ユーザーのカスタムプリセット
-  - type: preset
-    preset: company-logo # presets/company-logo.tsx
-    params:
-      scale: 1.5
-
-  # 別のカスタムプリセット
-  - type: preset
-    preset: my-custom # presets/my-custom.tsx
-```
-
-**重要: 実装側は区別しない**
-
-- `checker` も `company-logo` も同じ仕組みでロード
-- APIも同じ（`/api/presets` で全て返す）
-
----
-
-## 🔄 移行元コンポーネントの扱い
-
-現在、XSGには以下のコンポーネントが存在します：
-
-```
-frontend/src/components/patterns/
-├── Checker.tsx
-├── ColorBar.tsx
-├── CrossHatch.tsx
-├── GrayScale.tsx
-└── ...
-```
-
-### 移行方針
-
-**これらを `presets/` に移動する：**
-
-```bash
-# 移動
-mv frontend/src/components/patterns/*.tsx presets/
-
-# 結果
-presets/
-├── Checker.tsx      # 元: frontend/src/components/patterns/Checker.tsx
-├── ColorBar.tsx
-├── CrossHatch.tsx
-├── GrayScale.tsx
-└── ...
-```
-
-**変更点:**
-
-1. ファイルの配置場所が変わるだけ
-2. 実装は基本的に変更不要（Props型を統一）
-3. `preset` として使えるようになる
-
----
-
-## 🚀 プリセットの動的ロード
-
-```typescript
-// frontend/src/lib/presets.ts
-const PRESETS_CACHE = new Map<string, React.ComponentType>();
-
-export async function loadPreset(name: string) {
-  // キャッシュチェック
-  if (PRESETS_CACHE.has(name)) {
-    return PRESETS_CACHE.get(name);
-  }
-
-  try {
-    // presets/ から動的にインポート
-    const module = await import(`../../../presets/${name}.tsx`);
-    const PresetComponent = module.default;
-
-    // キャッシュに保存
-    PRESETS_CACHE.set(name, PresetComponent);
-
-    return PresetComponent;
-  } catch (err) {
-    throw new Error(
-      `Preset not found: ${name}\n` +
-      `Make sure presets/${name}.tsx exists.`
-    );
-  }
-}
-
-// 使用例
-const PresetComponent = await loadPreset('checker');
-return <PresetComponent params={node.params} />;
+  - id: defect-1
+    type: circle
+    x: 50%
+    y: 50%
+    diameter: 2
+    fill: "#FF0000"
 ```
 
 ---
 
-## 📋 プリセット開発ガイド
+## ロードと展開のパイプライン
 
-### 新しいプリセットを作る
+### ① パターン取得 `get_pattern`（extends 継承 ＋ `{{param}}` 置換）
 
-1. `presets/` に `.tsx` ファイルを作成
+- **Tauri**: Rust コマンド `get_pattern(pattern_id, params)`（`frontend/src-tauri/src/lib.rs` → `pattern_loader::load_pattern_with_params` → `pattern_expander.rs`）。`resolve_extends` でテンプレート継承、`expand` で `{{param}}` 置換を行う。
+- **Web**: `frontend/src/lib/tauriCompat.ts` の `loadPatternFromWeb`。`/patterns/<id>.yaml` を `fetch` → `paramExpander.ts` の `resolveExtends`（基底 YAML を再帰ロードしてマージ）→ `expandParams`（`{{param}}` 置換）。
+- 両モードの入口は `safeInvoke("get_pattern", { patternId, params })`（`isTauri()` で分岐）。
 
-```typescript
-// presets/my-pattern.tsx
-import { useEffect, useRef } from 'react';
-import type { PresetProps } from '@/lib/presets';
+この段階では `extends` と `{{param}}` は解決済みだが、**`background`/`preset` ノードはまだ残っている**。
 
-export default function MyPattern({ params }: PresetProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+#### `extends`（テンプレート継承）
 
-  useEffect(() => {
-    // 描画ロジック
-  }, [params]);
+子パターンの `extends: <base>.yaml` で基底パターンを継承する。`params`/`canvas`/`nodes` を子が上書きマージする（params はキー単位でマージ、canvas/nodes は子があれば子で置換）。
 
-  return <canvas ref={canvasRef} className="w-full h-full" />;
-}
-
-export const metadata = {
-  name: "My Pattern",
-  description: "独自のテストパターン",
-  params: {
-    color: { type: "color", default: "#FF0000" },
-  },
-};
-```
-
-2. YAMLで使用
+実例: `gradient.yaml`（基底） → `staircase.yaml` / `horizontal-gradient.yaml` / `vertical-gradient.yaml` が `extends: gradient.yaml`、`grayscale.yaml` が `extends: horizontal-gradient.yaml`。
 
 ```yaml
-- preset: my-pattern
-  params:
-    color: "#00FF00"
+# staircase.yaml
+extends: gradient.yaml
+params:
+  steps: { type: number, default: 21 }
+  direction: { type: string, default: "horizontal" }
 ```
 
-3. 完了！（リスタート不要、Hot Reload対応）
+> ⚠️ **既知のスキーマ欠落**: `extends` はコード（TS `resolveExtends` / Rust `resolve_extends`）では実装されているが、`xsg-pattern.schema.json` の top-level プロパティには宣言されていない（`required: ["canvas", "nodes"]` のみ）。`extends` を使うファイルはスキーマ検証を通らない可能性がある。スキーマへの `extends` 追加は別 Issue 候補。
+
+### ② プリセット展開 `expandPresets`（#23 新設）
+
+`frontend/src/lib/presetExpander.ts` の `expandPresets(pattern, getPattern, depth?)`。`pattern.nodes` を走査し:
+
+- `type === "background" | "preset"` のノードは、`node.preset`（参照先 id）を `getPattern(presetId, params)` で取得し、**再帰展開**した上で、その nodes を **同じ位置に差し込む**（z 順保持＝`background` を先頭に書けば背面に来る）。
+- それ以外のノードはそのまま残す。
+
+設計上の不変条件:
+
+- **id の名前空間化**: 展開した子ノードの `id` を `${hostId}/${childId}`（host に id が無ければ `preset-${index}/${childId}`）に書き換える。同じプリセットを複数回参照しても、プリセット内 id が兄弟と衝突しても、展開後 id が一意になり、描画側の React `key={node.id}` の重複を防ぐ。id 以外（type/座標/fill/z 順）は変えない。
+- **params の非伝播**: ユーザのクエリ params（`?pattern=...&size=...`）は **base パターンにのみ**適用され、プリセット参照の子には伝播しない。子プリセットは YAML 記述の `node.params` のみで解決される（プリセット params は作者固定）。`params` は `stringifyParams` で `Record<string,string>` 化して `get_pattern` に渡す。
+- **黒落ち防止**: 参照不能（`preset` 欠落・取得失敗・深度超過）な展開ノードは `console.warn` して **drop** し、他ノードの描画は継続する。`MAX_DEPTH = 16` で自己参照・相互参照の無限ループを防ぐ。
+- **入力不変**: 入力 `pattern` を破壊せず `{ ...pattern, nodes }` で新オブジェクトを返す（規律2: 定義 vs 状態の分離）。
+
+### ③ 結線 `loadResolvedPattern`（両モード共通）
+
+`frontend/src/lib/tauriCompat.ts` の `loadResolvedPattern(patternId, params)` が ① と ② を繋ぐ:
+
+```ts
+const base = await safeInvoke<XSGPattern>("get_pattern", { patternId, params });
+return expandPresets(base, (id, p) =>
+  safeInvoke<XSGPattern>("get_pattern", { patternId: id, params: p })
+);
+```
+
+`getPattern` として `safeInvoke("get_pattern", ...)` 自身を渡すので、参照先パターン（さらにその extends/param）も **モード適切に**（Tauri=Rust / web=fetch）解決される。描画サイトはこの 1 関数を呼ぶだけでよい。
+
+> **規律3（二重実装を作らない）**: プリセット展開ロジックは TS の `expandPresets` **1 箇所だけ**にある。Rust 側（`pattern_expander.rs`）には extends/param 展開はあるが **プリセット展開は無い**。両モードとも展開は TS 経由で行われる。
 
 ---
 
-## 🔍 プリセット一覧の取得
+## プリセット id の解決とセキュリティ
 
-### API
+`frontend/src/lib/patternId.ts` の `resolvePatternId(name)` がパターン名 → id を解決する。
 
-```bash
-GET /api/presets
-```
-
-**レスポンス:**
-
-```json
-{
-  "presets": [
-    {
-      "name": "checker",
-      "path": "/path/to/xsg/presets/checker.tsx",
-      "metadata": {
-        "name": "Checker",
-        "description": "市松模様パターン",
-        "author": "XSG Team",
-        "version": "1.0.0",
-        "params": {
-          "size": { "type": "number", "default": 50 }
-        }
-      }
-    },
-    {
-      "name": "company-logo",
-      "path": "/path/to/xsg/presets/company-logo.tsx",
-      "metadata": {
-        "name": "Company Logo",
-        "description": "会社ロゴ"
-      }
-    }
-  ]
-}
-```
-
-**重要: 「標準」と「カスタム」の区別はない**
+- エイリアステーブル `PATTERN_MAP`（`colorbars`→`colorbar`、`smpte`→`colorbar`、`grey`→`grayscale` 等）で canonical id へ。
+- 未知名は **安全な id（`SAFE_PATTERN_ID = /^[a-z0-9][a-z0-9-]*$/`）と確認できた場合のみ** passthrough（`colorbar-simple` のように `PATTERN_MAP` 未登録でもファイルが在ればロードできる）。
+- `/`・`\`・`.`・`..`・空白・その他不正文字を含む名前は **`"solid"` に倒す**。これにより Rust `pattern_expander.load_pattern_file` の `patterns_dir.join(path)` 経由でディレクトリ外の任意 `.yaml` を読まれる事故（パストラバーサル・拡張子注入）を遮断する。
+- `parsePatternParams(search)` がクエリ文字列から `pattern` キーを除いた params を集める。
 
 ---
 
-## 🎯 メリット
+## 同梱パターン一覧
 
-### 1. シンプル
+`frontend/public/patterns/` ＝ ルート `patterns/` の YAML 群（同じ実体）。例:
 
-- ❌ 「組み込み」「カスタム」の区別なし
-- ✅ 全て同じ仕組み
+```
+colorbar.yaml / colorbar-simple.yaml   # SMPTE カラーバー（基底 / プリセット参照版）
+ebu-colorbar.yaml / arib-colorbar.yaml
+grayscale.yaml / staircase.yaml / gradient.yaml
+horizontal-gradient.yaml / vertical-gradient.yaml
+checker.yaml / checker-with-dot.yaml / crosshatch.yaml
+convergence.yaml / pluge.yaml / multiburst.yaml / pixel-defect.yaml
+solid.yaml / image-example.yaml / ...
+```
 
-### 2. 拡張性
-
-- ✅ ユーザーは自由にプリセットを追加
-- ✅ 標準プリセットも編集・削除可能
-
-### 3. 一貫性
-
-- ✅ 全てのプリセットが同じ規約に従う
-- ✅ ドキュメントがシンプル
-
-### 4. 透明性
-
-- ✅ 標準プリセットのソースが見える
-- ✅ カスタマイズしやすい
+ユーザは YAML を自由に追加・編集・削除でき、`type: preset`/`background` から相互参照できる。「組み込み」と「カスタム」を実装側は区別しない。
 
 ---
 
-## 📂 Git管理
+## 関連ドキュメント
 
-### .gitignore
-
-```gitignore
-# ユーザーのカスタムプリセットを無視（オプション）
-# presets/*
-# !presets/checker.tsx
-# !presets/colorbar.tsx
-# ... 標準プリセットのみコミット
-```
-
-**または:**
-
-```gitignore
-# 全てのプリセットをコミット（推奨）
-# ユーザーがカスタムプリセットを追加してもOK
-```
+- スキーマ正本: `../../xsg-pattern.schema.json`、設計は `schema-orthogonality.md`
+- 座標・パス解決: `path-resolution.md`
+- Web/Canvas 描画: `web-rendering.md`
+- 拡張方法: `extensibility.md`
 
 ---
 
-## 🔄 既存コードの移行
+## 履歴
 
-### Phase 1: 既存コンポーネントを移動
-
-```bash
-# 既存のパターンコンポーネントを presets/ に移動
-mv frontend/src/components/patterns/*.tsx presets/
-```
-
-### Phase 2: PatternDisplay.tsx を簡素化
-
-```typescript
-// frontend/src/components/PatternDisplay.tsx
-import { loadPreset } from '@/lib/presets';
-
-export default function PatternDisplay({ pattern }: Props) {
-  const [PresetComponent, setPresetComponent] = useState(null);
-
-  useEffect(() => {
-    loadPreset(pattern).then(setPresetComponent);
-  }, [pattern]);
-
-  if (!PresetComponent) return <div>Loading...</div>;
-
-  return <PresetComponent params={{}} />;
-}
-```
-
-### Phase 3: 完全にYAMLベースへ
-
-```yaml
-# patterns/colorbar.yaml
-canvas:
-  width: 1920
-  height: 1080
-
-nodes:
-  - type: background
-    preset: colorbar # presets/ColorBar.tsx → presets/colorbar.tsx
-```
-
-```bash
-# 起動
-uv run python -m app.main --file patterns/colorbar.yaml
-```
-
----
-
-## ✅ まとめ
-
-**「組み込みプリセットはない。全てがプラグインである。」**
-
-| 項目             | 設計                                  |
-| ---------------- | ------------------------------------- |
-| プリセットの配置 | `presets/` ディレクトリ               |
-| 標準 vs カスタム | **区別しない**                        |
-| 実装の規約       | React Component、default export       |
-| 自動検出         | ファイル名 = プリセット名             |
-| Hot Reload       | ✅ 対応                               |
-| メタデータ       | `export const metadata`（オプション） |
-
-**利点:**
-
-1. ✅ シンプル（区別がない）
-2. ✅ 拡張性（自由に追加・編集・削除）
-3. ✅ 透明性（全てのソースが見える）
-4. ✅ 一貫性（全て同じ仕組み）
-
-これが真のプラグインアーキテクチャです。
+当初は「プリセット＝React `.tsx` コンポーネント」とし、`backend/app/presets.py`（FastAPI）が `presets/*.tsx` を自動検出して `GET /api/presets` で配る設計を構想していた。実装は Tauri + YAML + TypeScript へ移行し、プリセットは普通の YAML パターンファイル、参照は `type: background|preset` ノード、展開は TS の `expandPresets`（#23）に集約された。本文書はその現行実装を記述する。旧 `.tsx`/FastAPI 設計の詳細は破棄した。

--- a/xsg-pattern.schema.json
+++ b/xsg-pattern.schema.json
@@ -119,7 +119,7 @@
             "type": { "const": "background" },
             "preset": {
               "type": "string",
-              "description": "Preset name (from presets/ directory)"
+              "description": "Preset name = a pattern id under patterns/ (e.g. 'colorbar')"
             },
             "params": {
               "type": "object",
@@ -266,7 +266,7 @@
             "type": { "const": "preset" },
             "preset": {
               "type": "string",
-              "description": "Preset name (from presets/ directory)"
+              "description": "Preset name = a pattern id under patterns/ (e.g. 'colorbar')"
             },
             "params": {
               "type": "object",


### PR DESCRIPTION
## 関連 Issue
closes #27

## 概要
実装と全乖離していた2つの設計 docs を現行 TS 実装に即して改訂（doctrine 規律1: 動く前提の嘘 docs は最悪）。#23 で preset/座標解決の実装を精読した知見を反映。

## 変更
- **`path-resolution.md`**（414→174行）: 存在しない Python `backend/app/path_resolver.py`・`uv run python -m app.main` CLI・pytest を破棄。現行＝`frontend/src/lib/pathResolver.ts`（`PathResolver`/`parseCoordinate`/`evaluateCoordinate`、private `evaluateArithmetic`＝#4 で eval から置換）。**実装の非対称も正直に記述**（`resolvePath` を呼ぶのは SlideshowView だけ・NodeRenderer の image は生 src）。`calculateRepeatOffsets` は NodeRenderer 所在と訂正。
- **`preset-system.md`**（492→184行）: 存在しない「.tsx preset」「`backend/app/presets.py` FastAPI 自動検出」「`/api/presets`」を破棄。現行＝**YAML preset** + `type: background|preset` 参照ノード + 3段（`get_pattern` で extends/`{{param}}` → `expandPresets` で in-place 展開 → `loadResolvedPattern` 結線）。規律3（preset 展開は TS 1実装・Rust に無し）を明記。

各 doc 冒頭に legacy バナー、末尾に短い「## 履歴」。参照した全ファイルパス・シンボルは実在確認済み。

## 検証
- 2 docs に Python/.tsx 虚構の残骸なし（legacy バナー/履歴の「破棄された」記述を除く）。
- 参照シンボル（PathResolver/expandPresets/loadResolvedPattern/evaluateArithmetic/resolvePatternId/MAX_DEPTH/calculateRepeatOffsets）すべて実在。
- コード変更なし（docs のみ）。

## 追加で見つけたドリフト（本 PR 範囲外・別 Issue 候補）
- `migration-guide.md`（`uv run python migrate.py` 8箇所）・`migration-mapping.md`（Python ブロック）にも同種 Python 虚構。
- `xsg-pattern.schema.json` に `extends`（実装・実 YAML で使用）の宣言が無い（スキーマ欠落）。